### PR TITLE
Add responsive profile dashboard layout

### DIFF
--- a/frontend/src/components/profile/AccountInfoCard.tsx
+++ b/frontend/src/components/profile/AccountInfoCard.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import type { ProfileAccountInfo } from '../../types/profile'
+
+type AccountInfoCardProps = {
+  account: ProfileAccountInfo
+}
+
+const AccountInfoCard = ({ account }: AccountInfoCardProps) => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  const toggleVisibility = () => {
+    setIsOpen((current) => !current)
+  }
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Account Information</h2>
+          <p className="text-sm text-slate-500">
+            Update your contact details and personal bio to help buyers know you better.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
+          onClick={toggleVisibility}
+          aria-expanded={isOpen}
+        >
+          {isOpen ? 'Hide' : 'Show'}
+          <span aria-hidden="true">▾</span>
+        </button>
+      </header>
+      <div className={`${isOpen ? 'mt-4 flex flex-col gap-4' : 'hidden'} md:mt-4 md:flex md:flex-row md:items-start md:gap-10`}>
+        <dl className="space-y-3 text-sm text-slate-600 md:w-1/2">
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Name</dt>
+            <dd className="text-base font-medium text-slate-900">{account.name}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Email</dt>
+            <dd>{account.email}</dd>
+          </div>
+          {account.location ? (
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</dt>
+              <dd>{account.location}</dd>
+            </div>
+          ) : null}
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Member Since</dt>
+            <dd>{account.memberSince}</dd>
+          </div>
+        </dl>
+        {account.bio ? (
+          <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600 md:w-1/2">
+            <h3 className="text-sm font-semibold text-slate-900">Bio</h3>
+            <p className="mt-2 leading-relaxed">{account.bio}</p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+export default AccountInfoCard

--- a/frontend/src/components/profile/ListingTable.tsx
+++ b/frontend/src/components/profile/ListingTable.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import type { ProfileListingSummary } from '../../types/profile'
+
+type ListingTableProps = {
+  listings: ProfileListingSummary[]
+  title: string
+  emptyMessage?: string
+}
+
+const ListingTable = ({ listings, title, emptyMessage }: ListingTableProps) => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  const toggleVisibility = () => {
+    setIsOpen((current) => !current)
+  }
+
+  const containerClasses =
+    'rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition'
+
+  const contentWrapperClasses = `${isOpen ? 'mt-4 block' : 'hidden'} md:mt-4 md:block`
+
+  return (
+    <section className={containerClasses}>
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
+          onClick={toggleVisibility}
+          aria-expanded={isOpen}
+        >
+          {isOpen ? 'Hide' : 'Show'}
+          <span aria-hidden="true">▾</span>
+        </button>
+      </header>
+      {listings.length === 0 ? (
+        <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
+          {emptyMessage ?? 'No listings available yet.'}
+        </p>
+      ) : (
+        <div className={contentWrapperClasses}>
+          <div className="hidden overflow-x-auto md:block">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th className="px-3 py-2">Listing</th>
+                  <th className="px-3 py-2">Category</th>
+                  <th className="px-3 py-2">Price</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 text-sm text-slate-700">
+                {listings.map((listing) => (
+                  <tr key={listing.id} className="hover:bg-slate-50">
+                    <td className="px-3 py-3 font-medium text-slate-900">{listing.title}</td>
+                    <td className="px-3 py-3">{listing.category}</td>
+                    <td className="px-3 py-3 font-semibold text-slate-900">
+                      {listing.currency}
+                      {listing.price.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 capitalize">{listing.status}</td>
+                    <td className="px-3 py-3 text-slate-500">{listing.updatedAt}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex flex-col gap-4 md:hidden">
+            {listings.map((listing) => (
+              <article
+                key={listing.id}
+                className="rounded-xl border border-slate-100 bg-slate-50 p-4 shadow-sm"
+              >
+                <header className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-slate-900">{listing.title}</h3>
+                    <p className="text-xs uppercase tracking-wide text-slate-500">
+                      {listing.category}
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-primary">
+                    {listing.currency}
+                    {listing.price.toLocaleString()}
+                  </span>
+                </header>
+                <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-600">
+                  <div>
+                    <dt className="font-semibold text-slate-500">Status</dt>
+                    <dd className="capitalize text-slate-700">{listing.status}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-slate-500">Updated</dt>
+                    <dd>{listing.updatedAt}</dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default ListingTable

--- a/frontend/src/components/profile/PreferenceToggleList.tsx
+++ b/frontend/src/components/profile/PreferenceToggleList.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import type { ProfilePreferenceToggle } from '../../types/profile'
+
+type PreferenceToggleListProps = {
+  preferences: ProfilePreferenceToggle[]
+}
+
+const PreferenceToggleList = ({ preferences }: PreferenceToggleListProps) => {
+  const [toggles, setToggles] = useState(preferences)
+  const [isOpen, setIsOpen] = useState(true)
+  const itemClasses =
+    'flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 p-4 transition hover:border-primary/30 md:flex-row md:items-center md:justify-between'
+  const toggleBaseClasses =
+    'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
+  const indicatorBaseClasses =
+    'inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200'
+
+  const handleToggle = (id: string) => {
+    setToggles((current) =>
+      current.map((toggle) =>
+        toggle.id === id ? { ...toggle, enabled: !toggle.enabled } : toggle
+      )
+    )
+  }
+
+  const toggleSectionVisibility = () => {
+    setIsOpen((current) => !current)
+  }
+
+  const contentClasses = `${isOpen ? 'mt-4 space-y-4' : 'hidden'} md:mt-4 md:space-y-4 md:block`
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-slate-900">Communication Preferences</h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
+          onClick={toggleSectionVisibility}
+          aria-expanded={isOpen}
+        >
+          {isOpen ? 'Hide' : 'Show'}
+          <span aria-hidden="true">▾</span>
+        </button>
+      </header>
+      <p className={`${isOpen ? 'mt-2' : 'hidden'} text-sm text-slate-500 md:mt-2 md:block`}>
+        Choose how you want to receive alerts and updates from the marketplace.
+      </p>
+      <ul className={contentClasses}>
+        {toggles.map((toggle) => (
+          <li
+            key={toggle.id}
+            className={itemClasses}
+          >
+            <div>
+              <p className="text-sm font-semibold text-slate-900">{toggle.label}</p>
+              {toggle.description ? (
+                <p className="text-sm text-slate-600">{toggle.description}</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={() => handleToggle(toggle.id)}
+              className={`${toggle.enabled ? 'bg-primary' : 'bg-slate-300'} ${toggleBaseClasses}`}
+              aria-pressed={toggle.enabled}
+            >
+              <span className="sr-only">Toggle {toggle.label}</span>
+              <span
+                aria-hidden="true"
+                className={`${toggle.enabled ? 'translate-x-5' : 'translate-x-0'} ${indicatorBaseClasses}`}
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default PreferenceToggleList

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,47 @@
+import type { FC, ReactNode } from 'react'
+import type { ProfileAccountInfo, ProfileMetric } from '../../types/profile'
+
+type ProfileHeaderProps = {
+  account: ProfileAccountInfo
+  metrics?: ProfileMetric[]
+  actions?: ReactNode
+}
+
+const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions }) => {
+  return (
+    <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">Dashboard</p>
+          <h1 className="text-3xl font-semibold text-slate-900">{account.name}</h1>
+          <p className="mt-1 text-sm text-slate-600">{account.email}</p>
+          {account.location ? (
+            <p className="text-sm text-slate-600">Located in {account.location}</p>
+          ) : null}
+          <p className="mt-2 text-sm text-slate-500">Member since {account.memberSince}</p>
+        </div>
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+      {account.bio ? (
+        <p className="mt-4 max-w-2xl text-sm text-slate-600">{account.bio}</p>
+      ) : null}
+      {metrics.length > 0 ? (
+        <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-center"
+            >
+              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                {metric.label}
+              </dt>
+              <dd className="mt-1 text-xl font-semibold text-slate-900">{metric.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+    </header>
+  )
+}
+
+export default ProfileHeader

--- a/frontend/src/components/profile/SavedItemsCard.tsx
+++ b/frontend/src/components/profile/SavedItemsCard.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import type { ProfileSavedItemSummary } from '../../types/profile'
+
+type SavedItemsCardProps = {
+  items: ProfileSavedItemSummary[]
+}
+
+const SavedItemsCard = ({ items }: SavedItemsCardProps) => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  const toggleVisibility = () => {
+    setIsOpen((current) => !current)
+  }
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold text-slate-900">Saved &amp; Favorited</h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
+          onClick={toggleVisibility}
+          aria-expanded={isOpen}
+        >
+          {isOpen ? 'Hide' : 'Show'}
+          <span aria-hidden="true">▾</span>
+        </button>
+      </header>
+      {items.length === 0 ? (
+        <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
+          You have not saved any listings yet.
+        </p>
+      ) : (
+        <div className={`${isOpen ? 'mt-4 grid gap-4 sm:grid-cols-2' : 'hidden'} md:mt-4 md:grid`}>
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="flex flex-col gap-3 rounded-xl border border-slate-100 bg-slate-50 p-4 shadow-sm"
+            >
+              <div>
+                <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+                <p className="text-xs uppercase tracking-wide text-slate-500">{item.category}</p>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                <span className="font-semibold text-primary">
+                  {item.currency}
+                  {item.price.toLocaleString()}
+                </span>
+                <span className="text-xs text-slate-500">Saved {item.favoritedAt}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default SavedItemsCard

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,11 +1,130 @@
+import AccountInfoCard from '../components/profile/AccountInfoCard'
+import ListingTable from '../components/profile/ListingTable'
+import PreferenceToggleList from '../components/profile/PreferenceToggleList'
+import ProfileHeader from '../components/profile/ProfileHeader'
+import SavedItemsCard from '../components/profile/SavedItemsCard'
+import type {
+  ProfileAccountInfo,
+  ProfileListingSummary,
+  ProfileMetric,
+  ProfilePreferenceToggle,
+  ProfileSavedItemSummary,
+} from '../types/profile'
+
+const account: ProfileAccountInfo = {
+  name: 'Jamie Lawson',
+  email: 'jamie.lawson@example.com',
+  location: 'Seattle, WA',
+  memberSince: 'January 2021',
+  bio: 'Weekend warrior and outdoor gear collector. I list items that still have plenty of adventures left in them.',
+}
+
+const metrics: ProfileMetric[] = [
+  { label: 'Active Listings', value: 6 },
+  { label: 'Items Sold', value: 42 },
+  { label: 'Response Rate', value: '98%' },
+  { label: 'Avg. Rating', value: '4.9/5' },
+]
+
+const activeListings: ProfileListingSummary[] = [
+  {
+    id: 'listing-1',
+    title: 'Carbon Road Bike - Medium Frame',
+    category: 'Cycling',
+    price: 1450,
+    currency: '$',
+    status: 'active',
+    updatedAt: '2 days ago',
+  },
+  {
+    id: 'listing-2',
+    title: 'Climbing Protection Set (12 pcs)',
+    category: 'Climbing',
+    price: 260,
+    currency: '$',
+    status: 'active',
+    updatedAt: '5 days ago',
+  },
+  {
+    id: 'listing-3',
+    title: 'Camping Cookware Kit',
+    category: 'Camping',
+    price: 75,
+    currency: '$',
+    status: 'draft',
+    updatedAt: '1 hour ago',
+  },
+]
+
+const savedItems: ProfileSavedItemSummary[] = [
+  {
+    id: 'saved-1',
+    title: 'Trail Running Backpack',
+    category: 'Running',
+    price: 95,
+    currency: '$',
+    favoritedAt: '3 days ago',
+  },
+  {
+    id: 'saved-2',
+    title: 'Inflatable Paddle Board',
+    category: 'Water Sports',
+    price: 320,
+    currency: '$',
+    favoritedAt: '1 week ago',
+  },
+]
+
+const preferenceToggles: ProfilePreferenceToggle[] = [
+  {
+    id: 'notifications-email',
+    label: 'Email Updates',
+    description: 'Receive a summary of new messages, offers, and shipping updates via email.',
+    enabled: true,
+  },
+  {
+    id: 'notifications-sms',
+    label: 'SMS Alerts',
+    description: 'Get a text message when buyers send new offers or questions.',
+    enabled: false,
+  },
+  {
+    id: 'notifications-push',
+    label: 'Push Notifications',
+    description: 'Be alerted instantly when an item sells or requires your attention.',
+    enabled: true,
+  },
+]
+
 const Profile = () => {
   return (
-    <section className="mx-auto flex max-w-3xl flex-col gap-4 px-4 py-10">
-      <h1 className="text-3xl font-semibold text-primary">Your Profile</h1>
-      <p className="text-base text-slate-600">
-        Manage account information, saved listings, and marketplace preferences from
-        this dashboard.
-      </p>
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 lg:px-0">
+      <ProfileHeader
+        account={account}
+        metrics={metrics}
+        actions={
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary hover:text-white"
+          >
+            Create Listing
+          </button>
+        }
+      />
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <div className="flex flex-col gap-6">
+          <AccountInfoCard account={account} />
+          <ListingTable
+            listings={activeListings}
+            title="Active Listings"
+            emptyMessage="You do not have any listings yet. Start by creating your first listing."
+          />
+        </div>
+        <div className="flex flex-col gap-6">
+          <SavedItemsCard items={savedItems} />
+          <PreferenceToggleList preferences={preferenceToggles} />
+        </div>
+      </div>
     </section>
   )
 }

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,0 +1,40 @@
+export interface ProfileAccountInfo {
+  name: string
+  email: string
+  location?: string
+  memberSince: string
+  bio?: string
+}
+
+export interface ProfileListingSummary {
+  id: string
+  title: string
+  category: string
+  price: number
+  currency: string
+  status: 'active' | 'sold' | 'draft'
+  updatedAt: string
+  thumbnailUrl?: string
+}
+
+export interface ProfileSavedItemSummary {
+  id: string
+  title: string
+  category: string
+  price: number
+  currency: string
+  favoritedAt: string
+  thumbnailUrl?: string
+}
+
+export interface ProfileMetric {
+  label: string
+  value: string | number
+}
+
+export interface ProfilePreferenceToggle {
+  id: string
+  label: string
+  description?: string
+  enabled: boolean
+}


### PR DESCRIPTION
## Summary
- build reusable profile dashboard components for account info, listings, saved items, and preferences
- expand the profile page to render new sections with stubbed data models
- add profile-specific type definitions to guide future integrations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690384198898832ba14330699ab71563