### PR TITLE
Add create listing form UI with reusable form fields

### DIFF
--- a/frontend/src/components/forms/PhotoUploadField.tsx
+++ b/frontend/src/components/forms/PhotoUploadField.tsx
@@ -1,0 +1,114 @@
+import { useRef } from "react"
+import type { ChangeEvent, KeyboardEventHandler } from "react"
+
+export interface PhotoPreview {
+  id: string
+  url: string
+  fileName: string
+}
+
+export interface PhotoUploadFieldProps {
+  label: string
+  name: string
+  previews: PhotoPreview[]
+  onSelectFiles: (files: FileList | null) => void
+  onRemove: (id: string) => void
+  maxItems?: number
+  /** Optional handler to support drag-and-drop in a future iteration */
+  onDropFiles?: (files: File[]) => void
+  /** Optional handler to surface upload progress in a future iteration */
+  onUploadProgress?: (file: File, progress: number) => void
+  helperText?: string
+}
+
+const PhotoUploadField = ({
+  label,
+  name,
+  previews,
+  onSelectFiles,
+  onRemove,
+  maxItems = 6,
+  onDropFiles,
+  onUploadProgress,
+  helperText,
+}: PhotoUploadFieldProps) => {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target
+    if (files?.length && onUploadProgress) {
+      Array.from(files).forEach((file) => onUploadProgress(file, 0))
+    }
+    onSelectFiles(files)
+  }
+
+  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      inputRef.current?.click()
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+      <span>{label}</span>
+      {helperText ? (
+        <span className="text-xs font-normal text-slate-500">{helperText}</span>
+      ) : null}
+      <div
+        className="grid grid-cols-2 gap-4 sm:grid-cols-3"
+        onDrop={(event) => {
+          event.preventDefault()
+          if (onDropFiles) {
+            onDropFiles(Array.from(event.dataTransfer.files))
+          }
+          onSelectFiles(event.dataTransfer.files)
+        }}
+        onDragOver={(event) => event.preventDefault()}
+      >
+        {previews.map((preview) => (
+          <div key={preview.id} className="group relative aspect-square overflow-hidden rounded-lg border border-dashed border-slate-300">
+            <img
+              src={preview.url}
+              alt={preview.fileName}
+              className="h-full w-full object-cover"
+            />
+            <button
+              type="button"
+              className="absolute inset-0 hidden items-center justify-center bg-slate-900/70 text-xs font-semibold text-white transition group-hover:flex"
+              onClick={() => onRemove(preview.id)}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        {previews.length < maxItems ? (
+          <div
+            role="button"
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            onClick={() => inputRef.current?.click()}
+            className="flex aspect-square cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-slate-300 text-center text-xs font-normal text-slate-500 transition hover:border-primary hover:text-primary"
+          >
+            <span className="text-2xl" aria-hidden>
+              +
+            </span>
+            <span>Add photo</span>
+          </div>
+        ) : null}
+      </div>
+      <input
+        id={name}
+        ref={inputRef}
+        name={name}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+      />
+    </div>
+  )
+}
+
+export default PhotoUploadField

--- a/frontend/src/components/forms/PriceInput.tsx
+++ b/frontend/src/components/forms/PriceInput.tsx
@@ -1,0 +1,75 @@
+import type { InputHTMLAttributes } from "react"
+
+export interface PriceInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "onChange" | "value" | "type"> {
+  label: string
+  name: string
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  error?: string
+  currency?: string
+  description?: string
+}
+
+const PriceInput = ({
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  currency = "USD",
+  description,
+  placeholder,
+  required,
+  ...rest
+}: PriceInputProps) => {
+  const currencyLabel = currency.toUpperCase()
+
+  return (
+    <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+      <span>
+        {label}
+        {required ? <span className="ml-1 text-red-500">*</span> : null}
+      </span>
+      {description ? (
+        <span
+          id={`${name}-description`}
+          className="text-xs font-normal text-slate-500"
+        >
+          {description}
+        </span>
+      ) : null}
+      <div className="relative">
+        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-sm font-semibold text-slate-500">
+          {currencyLabel === "USD" ? "$" : currencyLabel}
+        </span>
+        <input
+          {...rest}
+          id={name}
+          name={name}
+          type="number"
+          inputMode="decimal"
+          min={0}
+          step="0.01"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          required={required}
+          className="w-full rounded-md border border-slate-300 px-3 py-2 pl-9 text-base text-slate-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? `${name}-error` : description ? `${name}-description` : undefined}
+        />
+      </div>
+      {error ? (
+        <span id={`${name}-error`} className="text-xs font-normal text-red-600">
+          {error}
+        </span>
+      ) : null}
+    </label>
+  )
+}
+
+export default PriceInput

--- a/frontend/src/components/forms/TextArea.tsx
+++ b/frontend/src/components/forms/TextArea.tsx
@@ -1,0 +1,64 @@
+import type { TextareaHTMLAttributes } from "react"
+
+export interface TextAreaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "className" | "onChange" | "value"> {
+  label: string
+  name: string
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  error?: string
+  description?: string
+}
+
+const TextArea = ({
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  description,
+  placeholder,
+  rows = 4,
+  required,
+  ...rest
+}: TextAreaProps) => {
+  return (
+    <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+      <span>
+        {label}
+        {required ? <span className="ml-1 text-red-500">*</span> : null}
+      </span>
+      {description ? (
+        <span
+          id={`${name}-description`}
+          className="text-xs font-normal text-slate-500"
+        >
+          {description}
+        </span>
+      ) : null}
+      <textarea
+        {...rest}
+        id={name}
+        name={name}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        rows={rows}
+        required={required}
+        className="rounded-md border border-slate-300 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? `${name}-error` : description ? `${name}-description` : undefined}
+      />
+      {error ? (
+        <span id={`${name}-error`} className="text-xs font-normal text-red-600">
+          {error}
+        </span>
+      ) : null}
+    </label>
+  )
+}
+
+export default TextArea

--- a/frontend/src/components/forms/TextInput.tsx
+++ b/frontend/src/components/forms/TextInput.tsx
@@ -1,0 +1,64 @@
+import type { InputHTMLAttributes } from "react"
+
+export interface TextInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "onChange" | "value"> {
+  label: string
+  name: string
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  error?: string
+  description?: string
+}
+
+const TextInput = ({
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  description,
+  type = "text",
+  placeholder,
+  required,
+  ...rest
+}: TextInputProps) => {
+  return (
+    <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+      <span>
+        {label}
+        {required ? <span className="ml-1 text-red-500">*</span> : null}
+      </span>
+      {description ? (
+        <span
+          id={`${name}-description`}
+          className="text-xs font-normal text-slate-500"
+        >
+          {description}
+        </span>
+      ) : null}
+      <input
+        {...rest}
+        id={name}
+        name={name}
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        required={required}
+        className="rounded-md border border-slate-300 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? `${name}-error` : description ? `${name}-description` : undefined}
+      />
+      {error ? (
+        <span id={`${name}-error`} className="text-xs font-normal text-red-600">
+          {error}
+        </span>
+      ) : null}
+    </label>
+  )
+}
+
+export default TextInput

--- a/frontend/src/components/forms/ToggleSwitch.tsx
+++ b/frontend/src/components/forms/ToggleSwitch.tsx
@@ -1,0 +1,56 @@
+import type { ButtonHTMLAttributes } from "react"
+
+export interface ToggleSwitchProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className" | "onChange" | "type"> {
+  label: string
+  name: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  description?: string
+  hint?: string
+}
+
+const ToggleSwitch = ({
+  label,
+  name,
+  checked,
+  onChange,
+  description,
+  hint,
+  disabled,
+  ...rest
+}: ToggleSwitchProps) => {
+  return (
+    <div className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col">
+          <span>{label}</span>
+          {description ? (
+            <span className="text-xs font-normal text-slate-500">{description}</span>
+          ) : null}
+        </div>
+        <button
+          {...rest}
+          id={name}
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          onClick={() => onChange(!checked)}
+          disabled={disabled}
+          className={`relative flex h-6 w-11 items-center rounded-full border transition focus:outline-none focus:ring-2 focus:ring-primary/20 ${
+            checked ? "border-primary bg-primary" : "border-slate-300 bg-slate-200"
+          } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+        >
+          <span
+            className={`inline-block h-5 w-5 translate-x-0 transform rounded-full bg-white shadow transition ${
+              checked ? "translate-x-5" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+      {hint ? <span className="text-xs font-normal text-slate-500">{hint}</span> : null}
+    </div>
+  )
+}
+
+export default ToggleSwitch

--- a/frontend/src/pages/CreateListing.tsx
+++ b/frontend/src/pages/CreateListing.tsx
@@ -1,11 +1,311 @@
+import { useEffect, useMemo, useState } from "react"
+import type { FormEvent } from "react"
+import PriceInput from "../components/forms/PriceInput"
+import TextArea from "../components/forms/TextArea"
+import TextInput from "../components/forms/TextInput"
+import ToggleSwitch from "../components/forms/ToggleSwitch"
+import PhotoUploadField, {
+  type PhotoPreview,
+} from "../components/forms/PhotoUploadField"
+
+type ListingFormValues = {
+  title: string
+  description: string
+  price: string
+  category: string
+  availability: string
+  contactPreference: string
+  active: boolean
+}
+
+type ListingFormErrors = Partial<Record<keyof ListingFormValues, string>>
+
+const INITIAL_VALUES: ListingFormValues = {
+  title: "",
+  description: "",
+  price: "",
+  category: "",
+  availability: "",
+  contactPreference: "",
+  active: true,
+}
+
+const CATEGORIES = ["Equipment", "Services", "Facilities", "Tickets", "Training"]
+const CONTACT_OPTIONS = ["Email", "Phone", "In-app messaging"]
+const MAX_PHOTOS = 6
+
+type ValidatorMap = {
+  [Field in keyof ListingFormValues]: (value: ListingFormValues[Field]) => string
+}
+
 const CreateListing = () => {
+  const [values, setValues] = useState<ListingFormValues>(INITIAL_VALUES)
+  const [errors, setErrors] = useState<ListingFormErrors>({})
+  const [photos, setPhotos] = useState<PhotoPreview[]>([])
+
+  const validators = useMemo<ValidatorMap>(
+    () => ({
+      title: (value: string) => {
+        if (!value.trim()) return "A title is required."
+        if (value.trim().length < 5) return "Titles should be at least 5 characters long."
+        return ""
+      },
+      description: (value: string) => {
+        if (!value.trim()) return "Describe your listing so buyers know what to expect."
+        if (value.trim().length < 20)
+          return "Please provide a bit more detail (minimum 20 characters)."
+        return ""
+      },
+      price: (value: string) => {
+        if (!value.trim()) return "Set a price for the listing."
+        const numeric = Number(value)
+        if (Number.isNaN(numeric) || numeric <= 0) return "Price must be a positive number."
+        return ""
+      },
+      category: (value: string) => {
+        if (!value) return "Select a category to help shoppers discover this item."
+        return ""
+      },
+      availability: (value: string) => {
+        if (!value.trim()) return "Let buyers know when this listing is available."
+        return ""
+      },
+      contactPreference: (value: string) => {
+        if (!value) return "Choose how you prefer to be contacted."
+        return ""
+      },
+      active: () => "",
+    }),
+    []
+  )
+
+  useEffect(() => {
+    return () => {
+      photos.forEach((preview) => URL.revokeObjectURL(preview.url))
+    }
+  }, [photos])
+
+  const runValidator = <Field extends keyof ListingFormValues>(field: Field, value: ListingFormValues[Field]) =>
+    validators[field](value)
+
+  const updateValue = <Field extends keyof ListingFormValues>(field: Field, value: ListingFormValues[Field]) => {
+    setValues((prev) => ({ ...prev, [field]: value }))
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: runValidator(field, value) }))
+    }
+  }
+
+  const validateField = <Field extends keyof ListingFormValues>(field: Field) => {
+    const error = runValidator(field, values[field])
+    setErrors((prev) => ({ ...prev, [field]: error }))
+    return error
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextErrors = (Object.keys(values) as Array<keyof ListingFormValues>).reduce<ListingFormErrors>(
+      (acc, field) => {
+        const error = runValidator(field, values[field])
+        if (error) acc[field] = error
+        return acc
+      },
+      {}
+    )
+    setErrors(nextErrors)
+
+    if (Object.keys(nextErrors).length === 0) {
+      // In a future iteration this payload will be submitted to the API.
+      // eslint-disable-next-line no-console
+      console.log({ ...values, photos })
+    }
+  }
+
+  const handlePhotoSelection = (files: FileList | null) => {
+    if (!files?.length) return
+
+    setPhotos((prev) => {
+      const newPreviews = Array.from(files).map<PhotoPreview>((file) => ({
+        id: `${file.name}-${file.lastModified}-${
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : Math.random().toString(36).slice(2)
+        }`,
+        url: URL.createObjectURL(file),
+        fileName: file.name,
+      }))
+
+      return [...prev, ...newPreviews].slice(0, MAX_PHOTOS)
+    })
+  }
+
+  const handleRemovePhoto = (id: string) => {
+    setPhotos((prev) => {
+      const removed = prev.find((preview) => preview.id === id)
+      if (removed) {
+        URL.revokeObjectURL(removed.url)
+      }
+      return prev.filter((preview) => preview.id !== id)
+    })
+  }
+
   return (
-    <section className="mx-auto flex max-w-3xl flex-col gap-4 px-4 py-10">
-      <h1 className="text-3xl font-semibold text-primary">Create a Listing</h1>
-      <p className="text-base text-slate-600">
-        This screen will guide sellers through adding new marketplace listings with
-        photos, pricing, and availability details.
-      </p>
+    <section className="mx-auto flex max-w-4xl flex-col gap-8 px-4 py-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold text-primary">Create a Listing</h1>
+        <p className="text-base text-slate-600">
+          Share the details of what you&apos;re offering so buyers know exactly what to expect.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-10">
+        <section className="flex flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Basic information</h2>
+            <p className="text-sm text-slate-500">This information appears at the top of your listing.</p>
+          </div>
+          <TextInput
+            label="Title"
+            name="title"
+            placeholder="e.g., Premium rowing machine rental"
+            value={values.title}
+            onChange={(value) => updateValue("title", value)}
+            onBlur={() => validateField("title")}
+            error={errors.title}
+            required
+          />
+          <TextArea
+            label="Description"
+            name="description"
+            placeholder="Describe the condition, what&apos;s included, and any other relevant details."
+            value={values.description}
+            onChange={(value) => updateValue("description", value)}
+            onBlur={() => validateField("description")}
+            error={errors.description}
+            required
+            rows={6}
+          />
+        </section>
+
+        <section className="flex flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Pricing &amp; discovery</h2>
+            <p className="text-sm text-slate-500">Help buyers understand the cost and how to find your listing.</p>
+          </div>
+          <PriceInput
+            label="Price"
+            name="price"
+            placeholder="0.00"
+            value={values.price}
+            onChange={(value) => updateValue("price", value)}
+            onBlur={() => validateField("price")}
+            error={errors.price}
+            required
+          />
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+            <span>
+              Category<span className="ml-1 text-red-500">*</span>
+            </span>
+            <select
+              name="category"
+              value={values.category}
+              onChange={(event) => updateValue("category", event.target.value)}
+              onBlur={() => validateField("category")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              aria-invalid={Boolean(errors.category)}
+            >
+              <option value="" disabled>
+                Select a category
+              </option>
+              {CATEGORIES.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+            {errors.category ? (
+              <span className="text-xs font-normal text-red-600">{errors.category}</span>
+            ) : null}
+          </label>
+        </section>
+
+        <section className="flex flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Availability &amp; preferences</h2>
+            <p className="text-sm text-slate-500">Let buyers know when you&apos;re available and the best way to reach you.</p>
+          </div>
+          <TextInput
+            label="Availability details"
+            name="availability"
+            placeholder="e.g., Weekdays after 5pm"
+            value={values.availability}
+            onChange={(value) => updateValue("availability", value)}
+            onBlur={() => validateField("availability")}
+            error={errors.availability}
+            required
+          />
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+            <span>
+              Contact preference<span className="ml-1 text-red-500">*</span>
+            </span>
+            <select
+              name="contactPreference"
+              value={values.contactPreference}
+              onChange={(event) => updateValue("contactPreference", event.target.value)}
+              onBlur={() => validateField("contactPreference")}
+              className="rounded-md border border-slate-300 px-3 py-2 text-base text-slate-900 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              aria-invalid={Boolean(errors.contactPreference)}
+            >
+              <option value="" disabled>
+                Select a contact method
+              </option>
+              {CONTACT_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            {errors.contactPreference ? (
+              <span className="text-xs font-normal text-red-600">{errors.contactPreference}</span>
+            ) : null}
+          </label>
+          <ToggleSwitch
+            label="Active listing"
+            name="active"
+            description="Disable this to hide the listing from buyers without deleting it."
+            hint="You can update this status at any time."
+            checked={values.active}
+            onChange={(checked) => updateValue("active", checked)}
+          />
+        </section>
+
+        <section className="flex flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Photos</h2>
+            <p className="text-sm text-slate-500">
+              Add up to six images to showcase your listing. Drag-and-drop and upload progress indicators can be wired up later
+              using the provided props.
+            </p>
+          </div>
+          <PhotoUploadField
+            label="Listing photos"
+            name="photos"
+            previews={photos}
+            onSelectFiles={handlePhotoSelection}
+            onRemove={handleRemovePhoto}
+            maxItems={MAX_PHOTOS}
+            helperText="Square images look best. You can drag and drop files onto this area in a future update."
+          />
+        </section>
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          >
+            Save draft
+          </button>
+        </div>
+      </form>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- replace the Create Listing placeholder with a structured multi-section form that validates inputs and previews selected photos
- add reusable text, textarea, price, toggle, and photo upload form components that surface inline error messaging
- include props for future drag-and-drop and upload progress integrations while limiting previews to supported slots

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69038423b464832bbc575754fb07c664