### PR TITLE
Add messaging route and conversation tooling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,50 @@
-import { BrowserRouter, NavLink, Route, Routes } from 'react-router-dom'
+import { type ReactElement } from 'react'
+import {
+  BrowserRouter,
+  NavLink,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom'
 
 import Auth from './pages/Auth'
 import CreateListing from './pages/CreateListing'
+import Messages from './pages/Messages'
 import Marketplace from './pages/Marketplace'
 import Profile from './pages/Profile'
+import { AUTH_TOKEN_STORAGE_KEY } from './constants/auth'
 
 const navigation = [
   { to: '/', label: 'Marketplace' },
   { to: '/listings/new', label: 'Create Listing' },
+  { to: '/messages', label: 'Messages' },
   { to: '/profile', label: 'Profile' },
   { to: '/auth', label: 'Sign In' },
 ]
+
+const RequireAuth = ({ children }: { children: ReactElement }) => {
+  const location = useLocation()
+  const token =
+    typeof window !== 'undefined'
+      ? window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
+      : null
+
+  if (!token) {
+    return (
+      <Navigate
+        to="/auth"
+        replace
+        state={{
+          from: location.pathname,
+          message: 'Please sign in to continue.',
+        }}
+      />
+    )
+  }
+
+  return children
+}
 
 const App = () => {
   return (
@@ -45,6 +79,14 @@ const App = () => {
           <Routes>
             <Route path="/" element={<Marketplace />} />
             <Route path="/listings/new" element={<CreateListing />} />
+            <Route
+              path="/messages"
+              element={
+                <RequireAuth>
+                  <Messages />
+                </RequireAuth>
+              }
+            />
             <Route path="/profile" element={<Profile />} />
             <Route path="/auth" element={<Auth />} />
           </Routes>

--- a/frontend/src/components/messages/ConversationList.tsx
+++ b/frontend/src/components/messages/ConversationList.tsx
@@ -1,0 +1,74 @@
+import type { ConversationSummary } from '../../services/conversations'
+
+interface ConversationListProps {
+  conversations: ConversationSummary[]
+  selectedId: string | null
+  onSelect: (conversationId: string) => void
+  isLoading?: boolean
+  error?: string | null
+}
+
+const ConversationList = ({
+  conversations,
+  selectedId,
+  onSelect,
+  isLoading = false,
+  error = null,
+}: ConversationListProps) => {
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-slate-500">
+        Loading conversations…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+        {error}
+      </div>
+    )
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-500">
+        You don’t have any conversations yet.
+      </div>
+    )
+  }
+
+  return (
+    <ul className="flex h-full flex-col gap-2">
+      {conversations.map((conversation) => {
+        const participantNames = conversation.participants
+          .map((participant) => participant.name || participant.email)
+          .join(', ')
+
+        const isActive = conversation.id === selectedId
+
+        return (
+          <li key={conversation.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(conversation.id)}
+              className={`w-full rounded-lg border px-4 py-3 text-left transition ${
+                isActive
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-transparent bg-white text-slate-700 hover:border-primary/40 hover:bg-primary/5'
+              }`}
+            >
+              <p className="text-sm font-semibold">{conversation.topic}</p>
+              <p className="mt-1 line-clamp-2 text-xs text-slate-500">
+                {participantNames}
+              </p>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default ConversationList

--- a/frontend/src/components/messages/MessageComposer.tsx
+++ b/frontend/src/components/messages/MessageComposer.tsx
@@ -1,0 +1,62 @@
+import { type FormEvent, useState } from 'react'
+
+interface MessageComposerProps {
+  onSend: (message: string) => Promise<void>
+  isSending?: boolean
+  error?: string | null
+}
+
+const MessageComposer = ({ onSend, isSending = false, error = null }: MessageComposerProps) => {
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!message.trim()) {
+      return
+    }
+
+    try {
+      await onSend(message.trim())
+      setMessage('')
+    } catch (sendError) {
+      console.error('Failed to send message', sendError)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label htmlFor="message" className="sr-only">
+          Message
+        </label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          rows={3}
+          placeholder="Write a message…"
+          className="w-full rounded-lg border border-slate-200 bg-white p-3 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          disabled={isSending}
+        />
+      </div>
+
+      {error ? (
+        <div className="text-sm text-red-600" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50"
+          disabled={isSending || !message.trim()}
+        >
+          {isSending ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default MessageComposer

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_TOKEN_STORAGE_KEY = 'olymarket.authToken'

--- a/frontend/src/hooks/useConversations.ts
+++ b/frontend/src/hooks/useConversations.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  ApiError,
+  getConversationMessages,
+  getConversations,
+  postConversationMessage,
+} from '../services/conversations'
+import type {
+  ConversationMessage,
+  ConversationSummary,
+} from '../services/conversations'
+
+type Status = 'idle' | 'loading' | 'success' | 'error'
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof ApiError) {
+    if (error.status === 403) {
+      return "You don't have permission to view this conversation."
+    }
+
+    if (error.status === 404) {
+      return 'This conversation could not be found.'
+    }
+
+    if (error.status === 401) {
+      return 'Your session has expired. Please sign in again.'
+    }
+
+    if (typeof error.message === 'string' && error.message.trim().length > 0) {
+      return error.message
+    }
+  }
+
+  return 'Something went wrong. Please try again in a moment.'
+}
+
+export interface UseConversationsResult {
+  conversations: ConversationSummary[]
+  conversationsStatus: Status
+  conversationsError: string | null
+  selectedConversationId: string | null
+  selectedConversation: ConversationSummary | null
+  selectConversation: (conversationId: string) => void
+  messages: ConversationMessage[]
+  messagesStatus: Status
+  messagesError: string | null
+  sendMessage: (body: string) => Promise<void>
+  sendStatus: Status
+  sendError: string | null
+  refreshMessages: () => Promise<void>
+  refreshConversations: () => Promise<void>
+}
+
+export const useConversations = (
+  token: string | null
+): UseConversationsResult => {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([])
+  const [conversationsStatus, setConversationsStatus] = useState<Status>('idle')
+  const [conversationsError, setConversationsError] = useState<string | null>(null)
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null)
+
+  const [messages, setMessages] = useState<ConversationMessage[]>([])
+  const [messagesStatus, setMessagesStatus] = useState<Status>('idle')
+  const [messagesError, setMessagesError] = useState<string | null>(null)
+
+  const [sendStatus, setSendStatus] = useState<Status>('idle')
+  const [sendError, setSendError] = useState<string | null>(null)
+
+  const loadConversations = useCallback(async () => {
+    if (!token) {
+      setConversations([])
+      setConversationsStatus('error')
+      setConversationsError('You need to sign in to view conversations.')
+      return
+    }
+
+    setConversationsStatus('loading')
+    setConversationsError(null)
+
+    try {
+      const data = await getConversations(token)
+      setConversations(data)
+      setConversationsStatus('success')
+
+      if (data.length > 0) {
+        setSelectedConversationId((current) => {
+          if (current && data.some((conversation) => conversation.id === current)) {
+            return current
+          }
+
+          return data[0]?.id ?? null
+        })
+      } else {
+        setSelectedConversationId(null)
+      }
+    } catch (error) {
+      setConversationsStatus('error')
+      setConversationsError(getErrorMessage(error))
+    }
+  }, [token])
+
+  const loadMessages = useCallback(
+    async (conversationId?: string) => {
+      const targetConversationId = conversationId ?? selectedConversationId
+      if (!token || !targetConversationId) {
+        setMessages([])
+        setMessagesStatus(token ? 'idle' : 'error')
+        setMessagesError(
+          token ? null : 'You need to sign in to view conversation messages.'
+        )
+        return
+      }
+
+      setMessagesStatus('loading')
+      setMessagesError(null)
+
+      try {
+        const data = await getConversationMessages(targetConversationId, token)
+        setMessages(data)
+        setMessagesStatus('success')
+      } catch (error) {
+        setMessagesStatus('error')
+        const message = getErrorMessage(error)
+        setMessagesError(message)
+
+        if (error instanceof ApiError && (error.status === 403 || error.status === 404)) {
+          // Prevent the UI from showing stale data for conversations the user can no longer access.
+          setMessages([])
+        }
+      }
+    },
+    [selectedConversationId, token]
+  )
+
+  useEffect(() => {
+    void loadConversations()
+  }, [loadConversations])
+
+  useEffect(() => {
+    if (selectedConversationId) {
+      void loadMessages(selectedConversationId)
+    } else {
+      setMessages([])
+      setMessagesStatus('idle')
+      setMessagesError(null)
+    }
+  }, [selectedConversationId, loadMessages])
+
+  const selectConversation = useCallback((conversationId: string) => {
+    setSelectedConversationId(conversationId)
+  }, [])
+
+  const sendMessage = useCallback(
+    async (body: string) => {
+      if (!token || !selectedConversationId) {
+        setSendStatus('error')
+        setSendError('Select a conversation before sending a message.')
+        return
+      }
+
+      if (!body.trim()) {
+        setSendStatus('error')
+        setSendError('Message cannot be empty.')
+        return
+      }
+
+      setSendStatus('loading')
+      setSendError(null)
+
+      try {
+        const message = await postConversationMessage(
+          selectedConversationId,
+          { body },
+          token
+        )
+        setMessages((current) => [...current, message])
+        setSendStatus('success')
+      } catch (error) {
+        setSendStatus('error')
+        setSendError(getErrorMessage(error))
+        throw error
+      }
+    },
+    [selectedConversationId, token]
+  )
+
+  const selectedConversation = useMemo(() => {
+    if (!selectedConversationId) return null
+    return (
+      conversations.find((conversation) => conversation.id === selectedConversationId) ??
+      null
+    )
+  }, [conversations, selectedConversationId])
+
+  const refreshMessages = useCallback(async () => {
+    await loadMessages()
+  }, [loadMessages])
+
+  const refreshConversations = useCallback(async () => {
+    await loadConversations()
+  }, [loadConversations])
+
+  return {
+    conversations,
+    conversationsStatus,
+    conversationsError,
+    selectedConversationId,
+    selectedConversation,
+    selectConversation,
+    messages,
+    messagesStatus,
+    messagesError,
+    sendMessage,
+    sendStatus,
+    sendError,
+    refreshMessages,
+    refreshConversations,
+  }
+}

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react'
+
+import ConversationList from '../components/messages/ConversationList'
+import MessageComposer from '../components/messages/MessageComposer'
+import { AUTH_TOKEN_STORAGE_KEY } from '../constants/auth'
+import { useConversations } from '../hooks/useConversations'
+
+const getInitialToken = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
+}
+
+const formatTimestamp = (timestamp: string) => {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toLocaleString()
+}
+
+const Messages = () => {
+  const token = useMemo(() => getInitialToken(), [])
+  const {
+    conversations,
+    conversationsStatus,
+    conversationsError,
+    selectedConversation,
+    selectedConversationId,
+    selectConversation,
+    messages,
+    messagesStatus,
+    messagesError,
+    sendMessage,
+    sendStatus,
+    sendError,
+  } = useConversations(token)
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 lg:px-0">
+      <header>
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Messages</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Stay in touch with other community members and keep conversations going.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+        <aside className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Conversations
+          </h2>
+          <div className="h-[480px] overflow-hidden rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <ConversationList
+              conversations={conversations}
+              selectedId={selectedConversationId}
+              onSelect={selectConversation}
+              isLoading={conversationsStatus === 'loading'}
+              error={conversationsError}
+            />
+          </div>
+        </aside>
+
+        <div className="flex min-h-[520px] flex-col rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          {selectedConversation ? (
+            <div className="flex flex-1 flex-col">
+              <div className="border-b border-slate-100 pb-4">
+                <h2 className="text-lg font-semibold text-slate-900">
+                  {selectedConversation.topic}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  {selectedConversation.participants
+                    .map((participant) => participant.name || participant.email)
+                    .join(', ')}
+                </p>
+              </div>
+
+              <div className="flex-1 space-y-4 overflow-y-auto py-6 pr-1">
+                {messagesStatus === 'loading' ? (
+                  <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                    Loading messages…
+                  </div>
+                ) : null}
+
+                {messagesStatus === 'error' && messagesError ? (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+                    {messagesError}
+                  </div>
+                ) : null}
+
+                {messagesStatus === 'success' && messages.length === 0 ? (
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                    No messages yet. Say hello to get things started!
+                  </div>
+                ) : null}
+
+                {messages.map((message) => (
+                  <div key={message.id} className="flex flex-col gap-1 rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <div className="flex items-center justify-between text-xs text-slate-500">
+                      <span className="font-medium text-slate-700">
+                        {message.sender.name || message.sender.email}
+                      </span>
+                      <span>{formatTimestamp(message.createdAt)}</span>
+                    </div>
+                    <p className="whitespace-pre-wrap text-sm text-slate-700">{message.body}</p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="border-t border-slate-100 pt-4">
+                {messagesStatus === 'error' ? (
+                  <p className="text-sm text-slate-500">
+                    Resolve the issue above before sending new messages.
+                  </p>
+                ) : (
+                  <MessageComposer
+                    onSend={sendMessage}
+                    isSending={sendStatus === 'loading'}
+                    error={sendError}
+                  />
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-1 flex-col items-center justify-center text-center text-slate-500">
+              {conversationsStatus === 'loading' ? (
+                <p>Loading conversations…</p>
+              ) : conversationsError ? (
+                <p>{conversationsError}</p>
+              ) : (
+                <p>Select a conversation to view messages.</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Messages

--- a/frontend/src/services/conversations.ts
+++ b/frontend/src/services/conversations.ts
@@ -1,0 +1,199 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:4000'
+
+export class ApiError extends Error {
+  status: number
+  details: unknown
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.details = details
+  }
+}
+
+export interface ConversationParticipant {
+  id: string
+  name: string
+  email: string
+}
+
+export interface ConversationSummary {
+  id: string
+  topic: string
+  participants: ConversationParticipant[]
+  createdAt: string
+  updatedAt: string
+}
+
+interface ConversationParticipantResponse {
+  id: string
+  lastReadAt: string | null
+  user: {
+    id: string
+    name: string | null
+    email: string
+  }
+}
+
+interface ConversationResponse {
+  id: string
+  topic: string
+  createdAt: string
+  updatedAt: string
+  participants: ConversationParticipantResponse[]
+}
+
+export interface ConversationMessage {
+  id: string
+  body: string
+  createdAt: string
+  updatedAt: string
+  sender: {
+    id: string
+    name: string
+    email: string
+  }
+}
+
+interface ConversationMessageResponse {
+  id: string
+  body: string
+  createdAt: string
+  updatedAt: string
+  sender: {
+    id: string
+    name: string | null
+    email: string
+  }
+}
+
+interface ConversationMessagePayload {
+  body: string
+}
+
+const buildHeaders = (token?: string, base?: HeadersInit): Headers => {
+  const headers = new Headers(base)
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  return headers
+}
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  const contentType = response.headers.get('content-type')
+  const isJson = contentType?.includes('application/json') ?? false
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`
+    let details: unknown
+
+    if (isJson) {
+      try {
+        details = await response.json()
+        if (typeof (details as { message?: string })?.message === 'string') {
+          message = (details as { message?: string }).message as string
+        }
+      } catch (error) {
+        details = undefined
+      }
+    }
+
+    throw new ApiError(message, response.status, details)
+  }
+
+  if (!isJson || response.status === 204) {
+    return undefined as T
+  }
+
+  return (await response.json()) as T
+}
+
+const mapConversation = (conversation: ConversationResponse): ConversationSummary => ({
+  id: conversation.id,
+  topic: conversation.topic,
+  createdAt: conversation.createdAt,
+  updatedAt: conversation.updatedAt,
+  participants: conversation.participants.map((participant) => ({
+    id: participant.user.id,
+    name: participant.user.name ?? participant.user.email,
+    email: participant.user.email,
+  })),
+})
+
+const mapMessage = (message: ConversationMessageResponse): ConversationMessage => ({
+  ...message,
+  sender: {
+    ...message.sender,
+    name: message.sender.name ?? message.sender.email,
+  },
+})
+
+export const getConversations = async (
+  token: string
+): Promise<ConversationSummary[]> => {
+  const response = await fetch(`${API_BASE_URL}/conversations`, {
+    headers: buildHeaders(token),
+  })
+
+  const data = await handleResponse<ConversationResponse[]>(response)
+  return data.map(mapConversation)
+}
+
+interface CreateConversationPayload {
+  topic: string
+  participantIds: string[]
+}
+
+export const createConversation = async (
+  payload: CreateConversationPayload,
+  token: string
+): Promise<ConversationSummary> => {
+  const response = await fetch(`${API_BASE_URL}/conversations`, {
+    method: 'POST',
+    headers: buildHeaders(token),
+    body: JSON.stringify(payload),
+  })
+
+  const data = await handleResponse<ConversationResponse>(response)
+  return mapConversation(data)
+}
+
+export const getConversationMessages = async (
+  conversationId: string,
+  token: string
+): Promise<ConversationMessage[]> => {
+  const response = await fetch(
+    `${API_BASE_URL}/conversations/${conversationId}/messages`,
+    {
+      headers: buildHeaders(token),
+    }
+  )
+
+  const data = await handleResponse<ConversationMessageResponse[]>(response)
+  return data.map(mapMessage)
+}
+
+export const postConversationMessage = async (
+  conversationId: string,
+  payload: ConversationMessagePayload,
+  token: string
+): Promise<ConversationMessage> => {
+  const response = await fetch(
+    `${API_BASE_URL}/conversations/${conversationId}/messages`,
+    {
+      method: 'POST',
+      headers: buildHeaders(token),
+      body: JSON.stringify(payload),
+    }
+  )
+
+  const data = await handleResponse<ConversationMessageResponse>(response)
+  return mapMessage(data)
+}


### PR DESCRIPTION
## Summary
- add a protected `/messages` route with auth guard and navigation entry
- build the messaging page layout, including conversation list, message feed, and composer
- create conversation service utilities and hooks to load threads, post messages, and surface API errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690386d10574832bad738f89eb5908e5