### PR TITLE
Connect marketplace listings to API

### DIFF
--- a/frontend/src/components/ListingCard.tsx
+++ b/frontend/src/components/ListingCard.tsx
@@ -1,15 +1,8 @@
 import type { FC } from 'react'
 
-export type Listing = {
-  id: string
-  title: string
-  description: string
-  price: number
-  category: string
-  location: string
-  imageUrl: string
-  postedAt: string
-}
+import type { Listing } from '../services/listings'
+
+type ListingWithMedia = Listing & { imageUrl?: string | null }
 
 const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -17,35 +10,81 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 })
 
+const formatPrice = (price: string) => {
+  const numericValue = Number.parseFloat(price)
+  if (Number.isNaN(numericValue)) {
+    return price
+  }
+
+  return currencyFormatter.format(numericValue)
+}
+
+const formatDateLabel = (value: string) => {
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Just now'
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(parsed)
+}
+
+const getInitials = (title: string) => {
+  const parts = title.trim().split(/\s+/)
+
+  if (parts.length === 0) {
+    return 'OLY'
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase()
+}
+
 type ListingCardProps = {
-  listing: Listing
+  listing: ListingWithMedia
 }
 
 const ListingCard: FC<ListingCardProps> = ({ listing }) => {
-  const { title, description, price, category, location, imageUrl, postedAt } = listing
+  const { title, description, price, owner, category, createdAt } = listing
+  const imageUrl = 'imageUrl' in listing ? listing.imageUrl : null
+  const categoryLabel = category?.name ?? 'Uncategorized'
+  const ownerName = owner?.name ?? 'Marketplace partner'
 
   return (
     <article className="card group h-full overflow-hidden">
       <div className="relative aspect-[4/3] overflow-hidden">
-        <img
-          src={imageUrl}
-          alt={title}
-          className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
-          loading="lazy"
-        />
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={title}
+            className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-3xl font-semibold text-slate-400">
+            {getInitials(title)}
+          </div>
+        )}
         <span className="absolute left-3 top-3 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
-          {category}
+          {categoryLabel}
         </span>
       </div>
       <div className="flex flex-1 flex-col gap-3 p-5">
         <div className="flex items-center justify-between text-sm text-slate-500">
-          <span>{location}</span>
-          <time dateTime={postedAt}>{postedAt}</time>
+          <span>{ownerName}</span>
+          <time dateTime={createdAt}>{formatDateLabel(createdAt)}</time>
         </div>
         <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-        <p className="text-sm text-slate-600">{description}</p>
+        <p className="text-sm text-slate-600 line-clamp-3">{description}</p>
         <div className="mt-auto flex items-center justify-between pt-3">
-          <span className="text-lg font-semibold text-primary">{currencyFormatter.format(price)}</span>
+          <span className="text-lg font-semibold text-primary">{formatPrice(price)}</span>
           <button
             type="button"
             className="btn-primary hidden rounded-full px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/80 sm:inline-flex"

--- a/frontend/src/hooks/useListings.ts
+++ b/frontend/src/hooks/useListings.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { fetchListings, type Listing } from '../services/listings'
+
+type ListingsState = {
+  listings: Listing[]
+  isLoading: boolean
+  isError: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export const useListings = (): ListingsState => {
+  const [listings, setListings] = useState<Listing[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const loadListings = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const data = await fetchListings()
+      setListings(data)
+    } catch (error) {
+      const normalizedError =
+        error instanceof Error
+          ? error
+          : new Error('Something went wrong while fetching listings.')
+      setError(normalizedError)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadListings()
+  }, [loadListings])
+
+  return useMemo(
+    () => ({
+      listings,
+      isLoading,
+      isError: Boolean(error),
+      error,
+      refetch: loadListings,
+    }),
+    [error, isLoading, listings, loadListings],
+  )
+}
+
+export default useListings

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,118 @@
+const normalizeBaseUrl = (value: string) => value.replace(/\/$/, '')
+
+const defaultBaseUrl = normalizeBaseUrl(
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000',
+)
+
+const buildUrl = (path: string, params?: Record<string, string | number | boolean | undefined>) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  const url = new URL(`${defaultBaseUrl}${normalizedPath}`)
+
+  if (params) {
+    Object.entries(params).forEach(([key, rawValue]) => {
+      if (typeof rawValue === 'undefined' || rawValue === null) {
+        return
+      }
+      url.searchParams.set(key, String(rawValue))
+    })
+  }
+
+  return url.toString()
+}
+
+const getAuthToken = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    return window.localStorage.getItem('authToken')
+  } catch (error) {
+    console.warn('Unable to access auth token from storage.', error)
+    return null
+  }
+}
+
+export type ApiRequestOptions = Omit<RequestInit, 'body'> & {
+  body?: unknown
+  params?: Record<string, string | number | boolean | undefined>
+  skipAuth?: boolean
+}
+
+const prepareBody = (body: unknown, headers: Headers): BodyInit | undefined => {
+  if (body === null || typeof body === 'undefined') {
+    return undefined
+  }
+
+  if (body instanceof FormData || body instanceof Blob || body instanceof ArrayBuffer) {
+    return body
+  }
+
+  if (typeof body === 'string') {
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'text/plain;charset=UTF-8')
+    }
+    return body
+  }
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  return JSON.stringify(body)
+}
+
+export async function apiClient<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+  const { params, headers: customHeaders, body, skipAuth, ...rest } = options
+  const url = buildUrl(path, params)
+
+  const headers = new Headers(customHeaders)
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json')
+  }
+
+  const token = skipAuth ? null : getAuthToken()
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  const preparedBody = prepareBody(body, headers)
+
+  const response = await fetch(url, {
+    method: rest.method ?? 'GET',
+    ...rest,
+    headers,
+    body: preparedBody,
+  })
+
+  const isJsonResponse = response.headers.get('content-type')?.includes('application/json') ?? false
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`
+
+    if (isJsonResponse) {
+      try {
+        const payload = (await response.json()) as { message?: string }
+        if (payload?.message) {
+          message = payload.message
+        }
+      } catch (error) {
+        console.error('Failed to parse error response', error)
+      }
+    }
+
+    throw new Error(message)
+  }
+
+  if (response.status === 204) {
+    return undefined as T
+  }
+
+  if (!isJsonResponse) {
+    return (await response.text()) as T
+  }
+
+  return (await response.json()) as T
+}
+
+export const API_BASE_URL = defaultBaseUrl

--- a/frontend/src/pages/CreateListing.tsx
+++ b/frontend/src/pages/CreateListing.tsx
@@ -115,7 +115,6 @@ const CreateListing = () => {
 
     if (Object.keys(nextErrors).length === 0) {
       // In a future iteration this payload will be submitted to the API.
-      // eslint-disable-next-line no-console
       console.log({ ...values, photos })
     }
   }

--- a/frontend/src/pages/Marketplace.tsx
+++ b/frontend/src/pages/Marketplace.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import CategoryFilter from '../components/CategoryFilter'
-import ListingCard, { type Listing } from '../components/ListingCard'
+import ListingCard from '../components/ListingCard'
 import PriceRangeFilter, { type PriceRangeOption } from '../components/PriceRangeFilter'
+import { useListings } from '../hooks/useListings'
 
 const priceRangeOptions: PriceRangeOption[] = [
   { id: 'all', label: 'Any budget', min: 0 },
@@ -11,95 +12,24 @@ const priceRangeOptions: PriceRangeOption[] = [
   { id: '150-plus', label: '$150 and up', min: 150 },
 ]
 
-const mockedListings: Listing[] = [
-  {
-    id: '1',
-    title: 'Opening Ceremony Tickets',
-    description:
-      'Secure seats for the spectacular opening ceremony with a panoramic view of the stadium and live performances.',
-    price: 320,
-    category: 'Tickets',
-    location: 'Paris, France',
-    imageUrl: 'https://images.unsplash.com/photo-1542337585-4abf19f93674?auto=format&fit=crop&w=800&q=80',
-    postedAt: '3 days ago',
-  },
-  {
-    id: '2',
-    title: 'Athlete Village Studio',
-    description:
-      'Modern studio located five minutes from the Olympic Village with flexible booking options for teams or solo travelers.',
-    price: 140,
-    category: 'Accommodation',
-    location: 'Saint-Denis, France',
-    imageUrl: 'https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=800&q=80',
-    postedAt: '2 days ago',
-  },
-  {
-    id: '3',
-    title: 'Guided Seine River Cruise',
-    description:
-      'Evening cruise tailored for Olympic visitors featuring iconic landmarks, music, and refreshments on board.',
-    price: 65,
-    category: 'Experiences',
-    location: 'Paris, France',
-    imageUrl: 'https://images.unsplash.com/photo-1522096823084-2d1aa1c4fbd0?auto=format&fit=crop&w=800&q=80',
-    postedAt: '5 hours ago',
-  },
-  {
-    id: '4',
-    title: 'Team Logistics Coordinator',
-    description:
-      'On-the-ground specialist to support transport, scheduling, and venue access throughout the competition week.',
-    price: 480,
-    category: 'Services',
-    location: 'Paris, France',
-    imageUrl: 'https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=800&q=80',
-    postedAt: '1 day ago',
-  },
-  {
-    id: '5',
-    title: 'Training Facility Rental',
-    description:
-      'Reserve a private indoor training facility complete with physio room, recovery stations, and secure storage.',
-    price: 260,
-    category: 'Facilities',
-    location: 'Aubervilliers, France',
-    imageUrl: 'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=800&q=80',
-    postedAt: '6 hours ago',
-  },
-  {
-    id: '6',
-    title: 'Local Guide Day Pass',
-    description:
-      'Hire a multilingual guide to navigate venues, cultural highlights, and fan zones with tailored itineraries.',
-    price: 95,
-    category: 'Services',
-    location: 'Paris, France',
-    imageUrl: 'https://images.unsplash.com/photo-1544025162-d76694265947?auto=format&fit=crop&w=800&q=80',
-    postedAt: '8 hours ago',
-  },
-]
+const parsePrice = (value: string) => {
+  const numericValue = Number.parseFloat(value)
+  return Number.isNaN(numericValue) ? null : numericValue
+}
 
 const Marketplace = () => {
-  const [isLoading, setIsLoading] = useState(true)
-  const [listings, setListings] = useState<Listing[]>([])
+  const { listings, isLoading, isError, error, refetch } = useListings()
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
-  const [selectedPriceRangeId, setSelectedPriceRangeId] = useState<string>('all')
+  const [selectedPriceRangeId, setSelectedPriceRangeId] = useState<string>(priceRangeOptions[0].id)
 
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setListings(mockedListings)
-      setIsLoading(false)
-    }, 600)
+  const categories = useMemo(() => {
+    const names = listings
+      .map((listing) => listing.category?.name?.trim())
+      .filter((name): name is string => Boolean(name && name.length > 0))
 
-    return () => window.clearTimeout(timeoutId)
-  }, [])
-
-  const categories = useMemo(
-    () => Array.from(new Set(listings.map((listing) => listing.category))).sort(),
-    [listings],
-  )
+    return Array.from(new Set(names)).sort()
+  }, [listings])
 
   const selectedPriceRange = useMemo(
     () => priceRangeOptions.find((option) => option.id === selectedPriceRangeId) ?? priceRangeOptions[0],
@@ -107,31 +37,42 @@ const Marketplace = () => {
   )
 
   const filteredListings = useMemo(() => {
-    const searchValue = searchTerm.trim().toLowerCase()
+    const normalizedSearch = searchTerm.trim().toLowerCase()
+    const maxPrice = selectedPriceRange.max ?? Number.POSITIVE_INFINITY
 
     return listings.filter((listing) => {
+      const priceValue = parsePrice(listing.price)
+      const matchesPrice =
+        priceValue === null ? true : priceValue >= selectedPriceRange.min && priceValue <= maxPrice
+
+      const categoryName = listing.category?.name ?? ''
+      const ownerName = listing.owner?.name ?? ''
+
+      const matchesCategory = !selectedCategory || categoryName === selectedCategory
+
       const matchesSearch =
-        searchValue.length === 0 ||
-        listing.title.toLowerCase().includes(searchValue) ||
-        listing.description.toLowerCase().includes(searchValue) ||
-        listing.location.toLowerCase().includes(searchValue)
-
-      const matchesCategory = !selectedCategory || listing.category === selectedCategory
-
-      const maxPrice = selectedPriceRange.max ?? Number.POSITIVE_INFINITY
-      const matchesPrice = listing.price >= selectedPriceRange.min && listing.price <= maxPrice
+        normalizedSearch.length === 0 ||
+        [listing.title, listing.description, categoryName, ownerName]
+          .map((value) => value.toLowerCase())
+          .some((value) => value.includes(normalizedSearch))
 
       return matchesSearch && matchesCategory && matchesPrice
     })
   }, [listings, searchTerm, selectedCategory, selectedPriceRange])
 
-  const showEmptyState = !isLoading && filteredListings.length === 0
+  const showEmptyState = !isLoading && !isError && filteredListings.length === 0
 
   const handleResetFilters = () => {
     setSearchTerm('')
     setSelectedCategory(null)
-    setSelectedPriceRangeId('all')
+    setSelectedPriceRangeId(priceRangeOptions[0].id)
   }
+
+  const headerMessage = isLoading
+    ? 'Fetching the latest marketplace updates...'
+    : isError
+      ? 'We were unable to load listings. Please try again.'
+      : `${filteredListings.length} result${filteredListings.length === 1 ? '' : 's'} ready for review.`
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-12 lg:px-8">
@@ -220,7 +161,7 @@ const Marketplace = () => {
             <CategoryFilter categories={categories} selected={selectedCategory} onSelect={setSelectedCategory} />
             <PriceRangeFilter
               options={priceRangeOptions}
-              selectedId={selectedPriceRange.id}
+              selectedId={selectedPriceRangeId}
               onSelect={(option) => setSelectedPriceRangeId(option.id)}
             />
           </div>
@@ -230,11 +171,7 @@ const Marketplace = () => {
           <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-2xl font-semibold text-slate-900">Featured listings</h2>
-              <p className="text-sm text-slate-500">
-                {isLoading
-                  ? 'Fetching the latest marketplace updates...'
-                  : `${filteredListings.length} result${filteredListings.length === 1 ? '' : 's'} ready for review.`}
-              </p>
+              <p className="text-sm text-slate-500">{headerMessage}</p>
             </div>
             <button
               type="button"
@@ -243,6 +180,29 @@ const Marketplace = () => {
               Save this search
             </button>
           </header>
+
+          {isError && (
+            <div className="card flex flex-col gap-4 p-8">
+              <div className="flex items-center gap-3 text-slate-900">
+                <span className="text-2xl">⚠️</span>
+                <div>
+                  <h3 className="text-lg font-semibold">We couldn't load the latest listings</h3>
+                  <p className="text-sm text-slate-600">
+                    {error?.message ?? 'Please refresh the page or try again in a moment.'}
+                  </p>
+                </div>
+              </div>
+              <div>
+                <button
+                  type="button"
+                  onClick={refetch}
+                  className="btn-primary inline-flex items-center rounded-full px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/60"
+                >
+                  Try again
+                </button>
+              </div>
+            </div>
+          )}
 
           {isLoading && (
             <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
@@ -280,7 +240,7 @@ const Marketplace = () => {
             </div>
           )}
 
-          {!isLoading && !showEmptyState && (
+          {!isLoading && !isError && !showEmptyState && (
             <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
               {filteredListings.map((listing) => (
                 <ListingCard key={listing.id} listing={listing} />

--- a/frontend/src/services/listings.ts
+++ b/frontend/src/services/listings.ts
@@ -1,0 +1,39 @@
+import { apiClient } from '../lib/apiClient'
+
+export type ListingCategory = {
+  id: string
+  name: string
+  slug: string
+}
+
+export type ListingOwner = {
+  id: string
+  name: string
+  email: string
+}
+
+export type Listing = {
+  id: string
+  title: string
+  description: string
+  price: string
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+  owner: ListingOwner
+  category: ListingCategory | null
+}
+
+export const fetchListings = async () => {
+  return apiClient<Listing[]>('/listings')
+}
+
+export const searchListings = async (term: string) => {
+  return apiClient<Listing[]>('/listings/search/query', {
+    params: { q: term },
+  })
+}
+
+export const fetchListingById = async (id: string) => {
+  return apiClient<Listing>(`/listings/${id}`)
+}


### PR DESCRIPTION
## Summary
- add a reusable API client that injects the base URL and authorization header
- create a listings service and hook to fetch marketplace data from the backend
- update the marketplace page and listing card to use live listings with loading and error states
- remove an unused eslint-disable comment from the create listing form so linting succeeds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690386b9b2dc832ba52fecf3abde8205