### PR TITLE
Persist and refresh authentication sessions

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { AppDataSource } from "../config";
 import { User } from "../entities/User";
 import { hashPassword, comparePassword } from "../utils/password";
 import { signToken } from "../utils/jwt";
+import { authMiddleware, AuthenticatedRequest } from "../middleware/auth";
 
 const router = Router();
 
@@ -52,6 +53,20 @@ router.post("/login", validationMiddleware(LoginDto), async (req, res) => {
       name: user.name,
     },
     token: signToken(user.id),
+  });
+});
+
+router.get("/me", authMiddleware, (req: AuthenticatedRequest, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: "Invalid token" });
+  }
+
+  return res.json({
+    user: {
+      id: req.user.id,
+      email: req.user.email,
+      name: req.user.name,
+    },
   });
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,8 @@ const RequireAuth = ({ children }: { children: ReactElement }) => {
 }
 
 const App = () => {
-  const { user, logout } = useAuth()
+  const { user, logout, isHydrated } = useAuth()
+  const userInitial = (user?.name || user?.email || '').charAt(0).toUpperCase()
 
   return (
     <BrowserRouter>
@@ -70,14 +71,25 @@ const App = () => {
                   {label}
                 </NavLink>
               ))}
-              {user ? (
-                <button
-                  type="button"
-                  onClick={logout}
-                  className="rounded-full px-3 py-1 text-slate-600 transition-colors hover:bg-slate-100"
-                >
-                  Sign Out
-                </button>
+              {!isHydrated ? (
+                <span className="text-slate-400">Loading...</span>
+              ) : user ? (
+                <div className="flex items-center gap-3">
+                  <NavLink to="/profile" className="group flex items-center gap-2">
+                    <span className="sr-only">View profile</span>
+                    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary transition group-hover:bg-primary group-hover:text-white">
+                      {userInitial || '?'}
+                    </span>
+                    <span className="text-slate-700 group-hover:text-primary">{user.name}</span>
+                  </NavLink>
+                  <button
+                    type="button"
+                    onClick={logout}
+                    className="rounded-full px-3 py-1 text-slate-600 transition-colors hover:bg-slate-100"
+                  >
+                    Sign Out
+                  </button>
+                </div>
               ) : (
                 <NavLink
                   to="/auth"

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,19 +2,25 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react"
 
 import { AUTH_TOKEN_STORAGE_KEY } from "../constants/auth"
+import { subscribeToUnauthorized, unsubscribeFromUnauthorized } from "../lib/authEvents"
+import { refreshSessionRequest } from "../services/auth"
 import { type AuthResponse, type AuthUser } from "../types/auth"
 
 type AuthContextValue = {
   user: AuthUser | null
   token: string | null
+  isHydrated: boolean
   login: (auth: AuthResponse) => void
   logout: () => void
+  refreshSession: () => Promise<AuthUser | null>
 }
 
 const STORAGE_KEY = "olymarket.auth"
@@ -23,7 +29,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined)
 
 type StoredAuth = AuthResponse
 
-const readStoredAuth = (): StoredAuth | null => {
+export const readStoredAuth = (): StoredAuth | null => {
   if (typeof window === "undefined") {
     return null
   }
@@ -59,30 +65,83 @@ const persistAuth = (auth: StoredAuth | null) => {
   window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, auth.token)
 }
 
-export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [user, setUser] = useState<AuthUser | null>(() => readStoredAuth()?.user ?? null)
-  const [token, setToken] = useState<string | null>(() => readStoredAuth()?.token ?? null)
+type AuthProviderProps = {
+  children: ReactNode
+  initialAuth?: StoredAuth | null
+}
+
+export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
+  const [user, setUser] = useState<AuthUser | null>(initialAuth?.user ?? null)
+  const [token, setToken] = useState<string | null>(initialAuth?.token ?? null)
+  const [isHydrated, setIsHydrated] = useState<boolean>(Boolean(initialAuth))
+  const hasAttemptedRefresh = useRef(false)
 
   const login = useCallback((auth: AuthResponse) => {
     setUser(auth.user)
     setToken(auth.token)
     persistAuth(auth)
+    setIsHydrated(true)
   }, [])
 
   const logout = useCallback(() => {
     setUser(null)
     setToken(null)
     persistAuth(null)
+    setIsHydrated(true)
   }, [])
+
+  const refreshSession = useCallback(async () => {
+    if (!token) {
+      setIsHydrated(true)
+      return null
+    }
+
+    try {
+      const currentUser = await refreshSessionRequest()
+      const nextAuth: StoredAuth = { user: currentUser, token }
+      setUser(currentUser)
+      persistAuth(nextAuth)
+      setIsHydrated(true)
+      return currentUser
+    } catch (error) {
+      logout()
+      throw error
+    }
+  }, [logout, token])
+
+  useEffect(() => {
+    if (!hasAttemptedRefresh.current) {
+      hasAttemptedRefresh.current = true
+      const stored = initialAuth ?? readStoredAuth()
+      if (stored && (!user || !token)) {
+        setUser(stored.user)
+        setToken(stored.token)
+      }
+      refreshSession().catch(() => undefined)
+    }
+  }, [initialAuth, refreshSession, token, user])
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      logout()
+    }
+
+    subscribeToUnauthorized(handleUnauthorized)
+    return () => {
+      unsubscribeFromUnauthorized(handleUnauthorized)
+    }
+  }, [logout])
 
   const value = useMemo(
     () => ({
       user,
       token,
+      isHydrated,
       login,
       logout,
+      refreshSession,
     }),
-    [login, logout, token, user]
+    [isHydrated, login, logout, refreshSession, token, user]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,9 +1,10 @@
 import { AUTH_TOKEN_STORAGE_KEY } from '../constants/auth'
+import { emitUnauthorized } from './authEvents'
 
 const normalizeBaseUrl = (value: string) => value.replace(/\/$/, '')
 
 const defaultBaseUrl = normalizeBaseUrl(
-  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000',
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000',
 )
 
 const buildUrl = (path: string, params?: Record<string, string | number | boolean | undefined>) => {
@@ -111,6 +112,10 @@ export async function apiClient<T>(path: string, options: ApiRequestOptions = {}
       } catch (error) {
         console.error('Failed to parse error response', error)
       }
+    }
+
+    if (response.status === 401) {
+      emitUnauthorized()
     }
 
     throw new ApiError(message, response.status)

--- a/frontend/src/lib/authEvents.ts
+++ b/frontend/src/lib/authEvents.ts
@@ -1,0 +1,19 @@
+const unauthorizedListeners = new Set<() => void>()
+
+export const subscribeToUnauthorized = (listener: () => void) => {
+  unauthorizedListeners.add(listener)
+}
+
+export const unsubscribeFromUnauthorized = (listener: () => void) => {
+  unauthorizedListeners.delete(listener)
+}
+
+export const emitUnauthorized = () => {
+  unauthorizedListeners.forEach((listener) => {
+    try {
+      listener()
+    } catch (error) {
+      console.error('Error handling unauthorized listener', error)
+    }
+  })
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { AuthProvider } from './context/AuthContext.tsx'
+import { AuthProvider, readStoredAuth } from './context/AuthContext.tsx'
+
+const initialAuth = readStoredAuth()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <AuthProvider>
+    <AuthProvider initialAuth={initialAuth}>
       <App />
     </AuthProvider>
   </StrictMode>,

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,8 +1,12 @@
+import { useMemo } from 'react'
+import { NavLink } from 'react-router-dom'
+
 import AccountInfoCard from '../components/profile/AccountInfoCard'
 import ListingTable from '../components/profile/ListingTable'
 import PreferenceToggleList from '../components/profile/PreferenceToggleList'
 import ProfileHeader from '../components/profile/ProfileHeader'
 import SavedItemsCard from '../components/profile/SavedItemsCard'
+import { useAuth } from '../context/AuthContext'
 import type {
   ProfileAccountInfo,
   ProfileListingSummary,
@@ -97,10 +101,43 @@ const preferenceToggles: ProfilePreferenceToggle[] = [
 ]
 
 const Profile = () => {
+  const { user, isHydrated } = useAuth()
+
+  const accountDetails = useMemo<ProfileAccountInfo>(() => ({
+    ...account,
+    name: user?.name ?? account.name,
+    email: user?.email ?? account.email,
+  }), [user])
+
+  if (!isHydrated) {
+    return (
+      <section className="mx-auto flex w-full max-w-4xl flex-col items-center justify-center px-4 py-24 text-slate-500">
+        Checking your profile...
+      </section>
+    )
+  }
+
+  if (!user) {
+    return (
+      <section className="mx-auto flex w-full max-w-4xl flex-col items-center justify-center gap-4 px-4 py-24 text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">You're not signed in</h1>
+        <p className="max-w-md text-sm text-slate-600">
+          Sign in to access your profile dashboard, manage listings, and review your saved items.
+        </p>
+        <NavLink
+          to="/auth"
+          className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+        >
+          Go to sign in
+        </NavLink>
+      </section>
+    )
+  }
+
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 lg:px-0">
       <ProfileHeader
-        account={account}
+        account={accountDetails}
         metrics={metrics}
         actions={
           <button
@@ -113,7 +150,7 @@ const Profile = () => {
       />
       <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
         <div className="flex flex-col gap-6">
-          <AccountInfoCard account={account} />
+          <AccountInfoCard account={accountDetails} />
           <ListingTable
             listings={activeListings}
             title="Active Listings"

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,7 +1,9 @@
+import { apiClient } from "../lib/apiClient"
 import type {
   AuthResponse,
   AuthCredentials,
   RegisterPayload,
+  AuthUser,
 } from "../types/auth"
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000"
@@ -55,5 +57,15 @@ export const login = async (payload: AuthCredentials): Promise<AuthResponse> => 
   })
 
   return handleResponse(response)
+}
+
+export const refreshSessionRequest = async (): Promise<AuthUser> => {
+  const response = await apiClient<{ user?: AuthUser }>("/auth/me")
+
+  if (!response?.user) {
+    throw new AuthServiceError("Malformed authentication response")
+  }
+
+  return response.user
 }
 


### PR DESCRIPTION
## Summary
- hydrate the auth provider from stored credentials and expose session refresh helpers
- add an API client unauthorized interceptor and lightweight /auth/me endpoint to validate tokens
- refresh navigation/profile UI to surface persisted authentication state and logout flows

## Testing
- npm --prefix frontend run build
- npm --prefix api run build *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_690390a9da34832b9996af0cfe069e0a