### PR TITLE
Refactor auth context helpers to satisfy lint rules

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ import CreateListing from './pages/CreateListing'
 import Messages from './pages/Messages'
 import Marketplace from './pages/Marketplace'
 import Profile from './pages/Profile'
-import { useAuth } from './context/AuthContext'
+import { useAuth } from './context/useAuth'
 
 const navigation = [
   { to: '/', label: 'Marketplace' },

--- a/frontend/src/context/AuthContext.shared.ts
+++ b/frontend/src/context/AuthContext.shared.ts
@@ -1,0 +1,13 @@
+import { createContext } from "react"
+import { type AuthResponse, type AuthUser } from "../types/auth"
+
+export type AuthContextValue = {
+  user: AuthUser | null
+  token: string | null
+  isHydrated: boolean
+  login: (auth: AuthResponse) => void
+  logout: () => void
+  refreshSession: () => Promise<AuthUser | null>
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined)

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,7 +1,5 @@
 import {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -9,61 +7,11 @@ import {
   type ReactNode,
 } from "react"
 
-import { AUTH_TOKEN_STORAGE_KEY } from "../constants/auth"
 import { subscribeToUnauthorized, unsubscribeFromUnauthorized } from "../lib/authEvents"
 import { refreshSessionRequest } from "../services/auth"
 import { type AuthResponse, type AuthUser } from "../types/auth"
-
-type AuthContextValue = {
-  user: AuthUser | null
-  token: string | null
-  isHydrated: boolean
-  login: (auth: AuthResponse) => void
-  logout: () => void
-  refreshSession: () => Promise<AuthUser | null>
-}
-
-const STORAGE_KEY = "olymarket.auth"
-
-const AuthContext = createContext<AuthContextValue | undefined>(undefined)
-
-type StoredAuth = AuthResponse
-
-export const readStoredAuth = (): StoredAuth | null => {
-  if (typeof window === "undefined") {
-    return null
-  }
-
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as StoredAuth
-    if (!parsed?.user || !parsed?.token) return null
-    const storedToken = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
-    if (!storedToken || storedToken !== parsed.token) {
-      window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, parsed.token)
-    }
-    return parsed
-  } catch (error) {
-    console.warn("Failed to parse stored auth", error)
-    return null
-  }
-}
-
-const persistAuth = (auth: StoredAuth | null) => {
-  if (typeof window === "undefined") {
-    return
-  }
-
-  if (!auth) {
-    window.localStorage.removeItem(STORAGE_KEY)
-    window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
-    return
-  }
-
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(auth))
-  window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, auth.token)
-}
+import { AuthContext } from "./AuthContext.shared"
+import { persistAuth, readStoredAuth, type StoredAuth } from "./authStorage"
 
 type AuthProviderProps = {
   children: ReactNode
@@ -145,12 +93,4 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
-}
-
-export const useAuth = () => {
-  const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error("useAuth must be used within an AuthProvider")
-  }
-  return context
 }

--- a/frontend/src/context/authStorage.ts
+++ b/frontend/src/context/authStorage.ts
@@ -1,0 +1,42 @@
+import { AUTH_TOKEN_STORAGE_KEY } from "../constants/auth"
+import { type AuthResponse } from "../types/auth"
+
+const STORAGE_KEY = "olymarket.auth"
+
+export type StoredAuth = AuthResponse
+
+export const readStoredAuth = (): StoredAuth | null => {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredAuth
+    if (!parsed?.user || !parsed?.token) return null
+    const storedToken = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
+    if (!storedToken || storedToken !== parsed.token) {
+      window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, parsed.token)
+    }
+    return parsed
+  } catch (error) {
+    console.warn("Failed to parse stored auth", error)
+    return null
+  }
+}
+
+export const persistAuth = (auth: StoredAuth | null) => {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  if (!auth) {
+    window.localStorage.removeItem(STORAGE_KEY)
+    window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY)
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(auth))
+  window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, auth.token)
+}

--- a/frontend/src/context/useAuth.ts
+++ b/frontend/src/context/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react"
+import { AuthContext } from "./AuthContext.shared"
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,8 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { AuthProvider, readStoredAuth } from './context/AuthContext.tsx'
+import { AuthProvider } from './context/AuthContext.tsx'
+import { readStoredAuth } from './context/authStorage.ts'
 
 const initialAuth = readStoredAuth()
 

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useMemo, useState } from "react"
 
 import { useFormValidation } from "../hooks/useFormValidation"
-import { useAuth } from "../context/AuthContext"
+import { useAuth } from "../context/useAuth"
 import { login as loginRequest, register as registerRequest } from "../services/auth"
 import { type AuthServiceError } from "../services/auth"
 

--- a/frontend/src/pages/CreateListing.tsx
+++ b/frontend/src/pages/CreateListing.tsx
@@ -9,7 +9,7 @@ import PhotoUploadField, {
   type PhotoPreview,
 } from "../components/forms/PhotoUploadField"
 import { ApiError } from "../lib/apiClient"
-import { useAuth } from "../context/AuthContext"
+import { useAuth } from "../context/useAuth"
 import {
   createListing,
   fetchListingCategories,

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -6,7 +6,7 @@ import ListingTable from '../components/profile/ListingTable'
 import PreferenceToggleList from '../components/profile/PreferenceToggleList'
 import ProfileHeader from '../components/profile/ProfileHeader'
 import SavedItemsCard from '../components/profile/SavedItemsCard'
-import { useAuth } from '../context/AuthContext'
+import { useAuth } from '../context/useAuth'
 import type {
   ProfileAccountInfo,
   ProfileListingSummary,

--- a/frontend/src/services/conversations.ts
+++ b/frontend/src/services/conversations.ts
@@ -100,7 +100,7 @@ const handleResponse = async <T>(response: Response): Promise<T> => {
         if (typeof (details as { message?: string })?.message === 'string') {
           message = (details as { message?: string }).message as string
         }
-      } catch (error) {
+      } catch {
         details = undefined
       }
     }


### PR DESCRIPTION
## Summary
- extract auth storage helpers into dedicated modules and split the useAuth hook for fast refresh compatibility
- update consumers to import the relocated hook and share the context definition
- adjust the conversations service error handling to satisfy linting rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690393e64404832bb28c84e8277a5d50