### PR TITLE
Ensure listings search route takes precedence

### DIFF
--- a/api/src/routes/listings.ts
+++ b/api/src/routes/listings.ts
@@ -43,6 +43,20 @@ router.get("/", async (req, res) => {
   return res.json(listings);
 });
 
+router.get("/search/query", async (req, res) => {
+  const term = (req.query.q as string) || "";
+  const listingRepository = AppDataSource.getRepository(Listing);
+  const listings = await listingRepository
+    .createQueryBuilder("listing")
+    .leftJoinAndSelect("listing.owner", "owner")
+    .leftJoinAndSelect("listing.category", "category")
+    .where("listing.title ILIKE :term", { term: `%${term}%` })
+    .orWhere("listing.description ILIKE :term", { term: `%${term}%` })
+    .orderBy("listing.created_at", "DESC")
+    .getMany();
+  return res.json(listings);
+});
+
 router.get("/:id", async (req, res) => {
   const listingRepository = AppDataSource.getRepository(Listing);
   const listing = await listingRepository.findOne({ where: { id: req.params.id } });
@@ -108,20 +122,6 @@ router.delete("/:id", authMiddleware, async (req: AuthenticatedRequest, res) => 
   }
   await listingRepository.remove(listing);
   return res.status(204).send();
-});
-
-router.get("/search/query", async (req, res) => {
-  const term = (req.query.q as string) || "";
-  const listingRepository = AppDataSource.getRepository(Listing);
-  const listings = await listingRepository
-    .createQueryBuilder("listing")
-    .leftJoinAndSelect("listing.owner", "owner")
-    .leftJoinAndSelect("listing.category", "category")
-    .where("listing.title ILIKE :term", { term: `%${term}%` })
-    .orWhere("listing.description ILIKE :term", { term: `%${term}%` })
-    .orderBy("listing.created_at", "DESC")
-    .getMany();
-  return res.json(listings);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- register the /listings/search/query route before the dynamic /:id route to ensure the explicit path is matched first

## Testing
- npx ts-node --transpile-only <<'TS' ... TS

------
https://chatgpt.com/codex/tasks/task_e_690395f8e8f8832bafd04b12ff3d29bc