### PR TITLE
Use shared API base URL in conversation service

### DIFF
--- a/frontend/src/services/conversations.ts
+++ b/frontend/src/services/conversations.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:4000'
+import { API_BASE_URL } from '../lib/apiClient'
 
 export class ApiError extends Error {
   status: number


### PR DESCRIPTION
## Summary
- import the shared API_BASE_URL constant so the conversation service matches the apiClient configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690395f74ff0832ba4d77ecaacbb23ae