### PR TITLE
Prevent user password hashes from leaking in API responses

### DIFF
--- a/api/src/entities/User.ts
+++ b/api/src/entities/User.ts
@@ -10,7 +10,7 @@ export class User extends BaseModel {
   @Column({ length: 255 })
   email!: string;
 
-  @Column({ name: "password_hash" })
+  @Column({ name: "password_hash", select: false })
   passwordHash!: string;
 
   @Column({ length: 150 })

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -36,7 +36,11 @@ router.post("/register", validationMiddleware(RegisterDto), async (req, res) => 
 
 router.post("/login", validationMiddleware(LoginDto), async (req, res) => {
   const userRepository = AppDataSource.getRepository(User);
-  const user = await userRepository.findOne({ where: { email: req.body.email } });
+  const user = await userRepository
+    .createQueryBuilder("user")
+    .addSelect("user.passwordHash")
+    .where("user.email = :email", { email: req.body.email })
+    .getOne();
   if (!user) {
     return res.status(401).json({ message: "Invalid credentials" });
   }


### PR DESCRIPTION
## Summary
- hide the `users.password_hash` column from default entity selections
- ensure the login flow explicitly selects the password hash for verification

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690395ea829c832ba08ec96bad2a6185