### PR TITLE
feat: fetch profile data for account dashboard

### DIFF
--- a/frontend/src/components/profile/AccountInfoCard.tsx
+++ b/frontend/src/components/profile/AccountInfoCard.tsx
@@ -2,14 +2,23 @@ import { useState } from 'react'
 import type { ProfileAccountInfo } from '../../types/profile'
 
 type AccountInfoCardProps = {
-  account: ProfileAccountInfo
+  account?: ProfileAccountInfo | null
+  isLoading?: boolean
 }
 
-const AccountInfoCard = ({ account }: AccountInfoCardProps) => {
+const AccountInfoCard = ({ account, isLoading = false }: AccountInfoCardProps) => {
   const [isOpen, setIsOpen] = useState(true)
 
   const toggleVisibility = () => {
     setIsOpen((current) => !current)
+  }
+
+  const renderValue = (value: string | undefined, placeholder: string) => {
+    if (value && value.trim().length > 0) {
+      return value
+    }
+
+    return placeholder
   }
 
   return (
@@ -31,33 +40,50 @@ const AccountInfoCard = ({ account }: AccountInfoCardProps) => {
           <span aria-hidden="true">▾</span>
         </button>
       </header>
-      <div className={`${isOpen ? 'mt-4 flex flex-col gap-4' : 'hidden'} md:mt-4 md:flex md:flex-row md:items-start md:gap-10`}>
-        <dl className="space-y-3 text-sm text-slate-600 md:w-1/2">
-          <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Name</dt>
-            <dd className="text-base font-medium text-slate-900">{account.name}</dd>
-          </div>
-          <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Email</dt>
-            <dd>{account.email}</dd>
-          </div>
-          {account.location ? (
-            <div>
-              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</dt>
-              <dd>{account.location}</dd>
+      <div
+        className={`${
+          isOpen ? 'mt-4 flex flex-col gap-4' : 'hidden'
+        } md:mt-4 md:flex md:flex-row md:items-start md:gap-10`}
+      >
+        {isLoading ? (
+          <p className="text-sm text-slate-500">Loading your account information…</p>
+        ) : account ? (
+          <>
+            <dl className="space-y-3 text-sm text-slate-600 md:w-1/2">
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Name</dt>
+                <dd className="text-base font-medium text-slate-900">
+                  {renderValue(account.name, 'Not provided yet')}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Email</dt>
+                <dd>{renderValue(account.email, 'Not provided yet')}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Location</dt>
+                <dd>{renderValue(account.location, 'Not provided yet')}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Member Since</dt>
+                <dd>{renderValue(account.memberSince, 'Not available yet')}</dd>
+              </div>
+            </dl>
+            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600 md:w-1/2">
+              <h3 className="text-sm font-semibold text-slate-900">Bio</h3>
+              <p className="mt-2 leading-relaxed">
+                {renderValue(
+                  account.bio,
+                  'You have not added a bio yet. Share a short introduction to help other members get to know you.',
+                )}
+              </p>
             </div>
-          ) : null}
-          <div>
-            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Member Since</dt>
-            <dd>{account.memberSince}</dd>
-          </div>
-        </dl>
-        {account.bio ? (
-          <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-600 md:w-1/2">
-            <h3 className="text-sm font-semibold text-slate-900">Bio</h3>
-            <p className="mt-2 leading-relaxed">{account.bio}</p>
-          </div>
-        ) : null}
+          </>
+        ) : (
+          <p className="text-sm text-slate-500">
+            Set up your account details to help buyers learn more about who you are.
+          </p>
+        )}
       </div>
     </section>
   )

--- a/frontend/src/components/profile/ListingTable.tsx
+++ b/frontend/src/components/profile/ListingTable.tsx
@@ -5,9 +5,10 @@ type ListingTableProps = {
   listings: ProfileListingSummary[]
   title: string
   emptyMessage?: string
+  isLoading?: boolean
 }
 
-const ListingTable = ({ listings, title, emptyMessage }: ListingTableProps) => {
+const ListingTable = ({ listings, title, emptyMessage, isLoading = false }: ListingTableProps) => {
   const [isOpen, setIsOpen] = useState(true)
 
   const toggleVisibility = () => {
@@ -33,7 +34,11 @@ const ListingTable = ({ listings, title, emptyMessage }: ListingTableProps) => {
           <span aria-hidden="true">▾</span>
         </button>
       </header>
-      {listings.length === 0 ? (
+      {isLoading && listings.length === 0 ? (
+        <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
+          Loading your listings…
+        </p>
+      ) : listings.length === 0 ? (
         <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
           {emptyMessage ?? 'No listings available yet.'}
         </p>

--- a/frontend/src/components/profile/PreferenceToggleList.tsx
+++ b/frontend/src/components/profile/PreferenceToggleList.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ProfilePreferenceToggle } from '../../types/profile'
 
 type PreferenceToggleListProps = {
   preferences: ProfilePreferenceToggle[]
+  isLoading?: boolean
 }
 
-const PreferenceToggleList = ({ preferences }: PreferenceToggleListProps) => {
+const PreferenceToggleList = ({ preferences, isLoading = false }: PreferenceToggleListProps) => {
   const [toggles, setToggles] = useState(preferences)
   const [isOpen, setIsOpen] = useState(true)
   const itemClasses =
@@ -14,6 +15,10 @@ const PreferenceToggleList = ({ preferences }: PreferenceToggleListProps) => {
     'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
   const indicatorBaseClasses =
     'inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200'
+
+  useEffect(() => {
+    setToggles(preferences)
+  }, [preferences])
 
   const handleToggle = (id: string) => {
     setToggles((current) =>
@@ -46,33 +51,41 @@ const PreferenceToggleList = ({ preferences }: PreferenceToggleListProps) => {
       <p className={`${isOpen ? 'mt-2' : 'hidden'} text-sm text-slate-500 md:mt-2 md:block`}>
         Choose how you want to receive alerts and updates from the marketplace.
       </p>
-      <ul className={contentClasses}>
-        {toggles.map((toggle) => (
-          <li
-            key={toggle.id}
-            className={itemClasses}
-          >
-            <div>
-              <p className="text-sm font-semibold text-slate-900">{toggle.label}</p>
-              {toggle.description ? (
-                <p className="text-sm text-slate-600">{toggle.description}</p>
-              ) : null}
-            </div>
-            <button
-              type="button"
-              onClick={() => handleToggle(toggle.id)}
-              className={`${toggle.enabled ? 'bg-primary' : 'bg-slate-300'} ${toggleBaseClasses}`}
-              aria-pressed={toggle.enabled}
+      {toggles.length > 0 ? (
+        <ul className={contentClasses}>
+          {toggles.map((toggle) => (
+            <li
+              key={toggle.id}
+              className={itemClasses}
             >
-              <span className="sr-only">Toggle {toggle.label}</span>
-              <span
-                aria-hidden="true"
-                className={`${toggle.enabled ? 'translate-x-5' : 'translate-x-0'} ${indicatorBaseClasses}`}
-              />
-            </button>
-          </li>
-        ))}
-      </ul>
+              <div>
+                <p className="text-sm font-semibold text-slate-900">{toggle.label}</p>
+                {toggle.description ? (
+                  <p className="text-sm text-slate-600">{toggle.description}</p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={() => handleToggle(toggle.id)}
+                className={`${toggle.enabled ? 'bg-primary' : 'bg-slate-300'} ${toggleBaseClasses}`}
+                aria-pressed={toggle.enabled}
+              >
+                <span className="sr-only">Toggle {toggle.label}</span>
+                <span
+                  aria-hidden="true"
+                  className={`${toggle.enabled ? 'translate-x-5' : 'translate-x-0'} ${indicatorBaseClasses}`}
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
+          {isLoading
+            ? 'Loading your communication preferences…'
+            : 'You have not configured any communication preferences yet.'}
+        </p>
+      )}
     </section>
   )
 }

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -2,30 +2,43 @@ import type { FC, ReactNode } from 'react'
 import type { ProfileAccountInfo, ProfileMetric } from '../../types/profile'
 
 type ProfileHeaderProps = {
-  account: ProfileAccountInfo
+  account?: ProfileAccountInfo | null
   metrics?: ProfileMetric[]
   actions?: ReactNode
+  isLoading?: boolean
 }
 
-const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions }) => {
+const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions, isLoading = false }) => {
+  const displayName = account?.name ?? (isLoading ? 'Loading profile…' : 'Your profile')
+  const displayEmail = account?.email
+  const hasMetrics = metrics.length > 0
+
   return (
     <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
           <p className="text-sm font-semibold uppercase tracking-wide text-primary">Dashboard</p>
-          <h1 className="text-3xl font-semibold text-slate-900">{account.name}</h1>
-          <p className="mt-1 text-sm text-slate-600">{account.email}</p>
-          {account.location ? (
+          <h1 className="text-3xl font-semibold text-slate-900">{displayName}</h1>
+          {displayEmail ? (
+            <p className="mt-1 text-sm text-slate-600">{displayEmail}</p>
+          ) : null}
+          {account?.location ? (
             <p className="text-sm text-slate-600">Located in {account.location}</p>
           ) : null}
-          <p className="mt-2 text-sm text-slate-500">Member since {account.memberSince}</p>
+          {account?.memberSince ? (
+            <p className="mt-2 text-sm text-slate-500">Member since {account.memberSince}</p>
+          ) : !isLoading ? (
+            <p className="mt-2 text-sm text-slate-500">
+              Complete your profile details to share more about yourself with the community.
+            </p>
+          ) : null}
         </div>
         {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
       </div>
-      {account.bio ? (
+      {account?.bio ? (
         <p className="mt-4 max-w-2xl text-sm text-slate-600">{account.bio}</p>
       ) : null}
-      {metrics.length > 0 ? (
+      {hasMetrics ? (
         <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {metrics.map((metric) => (
             <div
@@ -39,6 +52,8 @@ const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions 
             </div>
           ))}
         </dl>
+      ) : isLoading ? (
+        <p className="mt-6 text-sm text-slate-500">Loading your latest metrics…</p>
       ) : null}
     </header>
   )

--- a/frontend/src/components/profile/SavedItemsCard.tsx
+++ b/frontend/src/components/profile/SavedItemsCard.tsx
@@ -3,9 +3,10 @@ import type { ProfileSavedItemSummary } from '../../types/profile'
 
 type SavedItemsCardProps = {
   items: ProfileSavedItemSummary[]
+  isLoading?: boolean
 }
 
-const SavedItemsCard = ({ items }: SavedItemsCardProps) => {
+const SavedItemsCard = ({ items, isLoading = false }: SavedItemsCardProps) => {
   const [isOpen, setIsOpen] = useState(true)
 
   const toggleVisibility = () => {
@@ -26,7 +27,11 @@ const SavedItemsCard = ({ items }: SavedItemsCardProps) => {
           <span aria-hidden="true">▾</span>
         </button>
       </header>
-      {items.length === 0 ? (
+      {isLoading && items.length === 0 ? (
+        <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
+          Loading your saved items…
+        </p>
+      ) : items.length === 0 ? (
         <p className={`${isOpen ? 'mt-4' : 'hidden'} text-sm text-slate-500 md:mt-4 md:block`}>
           You have not saved any listings yet.
         </p>

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { ApiError } from '../lib/apiClient'
+import {
+  fetchProfileAccount,
+  fetchProfileActiveListings,
+  fetchProfileMetrics,
+  fetchProfilePreferences,
+  fetchProfileSavedItems,
+} from '../services/profile'
+import type {
+  ProfileAccountInfo,
+  ProfileListingSummary,
+  ProfileMetric,
+  ProfilePreferenceToggle,
+  ProfileSavedItemSummary,
+} from '../types/profile'
+
+type ProfileData = {
+  account: ProfileAccountInfo | null
+  metrics: ProfileMetric[]
+  activeListings: ProfileListingSummary[]
+  savedItems: ProfileSavedItemSummary[]
+  preferences: ProfilePreferenceToggle[]
+}
+
+type UseProfileOptions = {
+  enabled?: boolean
+}
+
+type UseProfileState = ProfileData & {
+  isLoading: boolean
+  isError: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+const EMPTY_PROFILE_DATA: ProfileData = {
+  account: null,
+  metrics: [],
+  activeListings: [],
+  savedItems: [],
+  preferences: [],
+}
+
+const resolveOrFallback = async <T>(operation: () => Promise<T>, fallback: T): Promise<T> => {
+  try {
+    const result = await operation()
+
+    if (typeof result === 'undefined' || result === null) {
+      return fallback
+    }
+
+    return result
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return fallback
+    }
+
+    throw error
+  }
+}
+
+export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfileState => {
+  const [data, setData] = useState<ProfileData>(EMPTY_PROFILE_DATA)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const loadProfile = useCallback(async () => {
+    if (!enabled) {
+      setData(EMPTY_PROFILE_DATA)
+      setError(null)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const [account, metrics, activeListings, savedItems, preferences] = await Promise.all([
+        resolveOrFallback<ProfileAccountInfo | null>(fetchProfileAccount, null),
+        resolveOrFallback<ProfileMetric[]>(fetchProfileMetrics, []),
+        resolveOrFallback<ProfileListingSummary[]>(fetchProfileActiveListings, []),
+        resolveOrFallback<ProfileSavedItemSummary[]>(fetchProfileSavedItems, []),
+        resolveOrFallback<ProfilePreferenceToggle[]>(fetchProfilePreferences, []),
+      ])
+
+      setData({
+        account,
+        metrics,
+        activeListings,
+        savedItems,
+        preferences,
+      })
+    } catch (error) {
+      const normalizedError =
+        error instanceof Error
+          ? error
+          : new Error('Something went wrong while loading your profile data.')
+
+      setError(normalizedError)
+      setData(EMPTY_PROFILE_DATA)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    loadProfile()
+  }, [loadProfile])
+
+  return useMemo(
+    () => ({
+      ...data,
+      isLoading,
+      isError: Boolean(error),
+      error,
+      refetch: loadProfile,
+    }),
+    [data, error, isLoading, loadProfile],
+  )
+}
+
+export default useProfile

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -7,107 +7,48 @@ import PreferenceToggleList from '../components/profile/PreferenceToggleList'
 import ProfileHeader from '../components/profile/ProfileHeader'
 import SavedItemsCard from '../components/profile/SavedItemsCard'
 import { useAuth } from '../context/useAuth'
-import type {
-  ProfileAccountInfo,
-  ProfileListingSummary,
-  ProfileMetric,
-  ProfilePreferenceToggle,
-  ProfileSavedItemSummary,
-} from '../types/profile'
-
-const account: ProfileAccountInfo = {
-  name: 'Jamie Lawson',
-  email: 'jamie.lawson@example.com',
-  location: 'Seattle, WA',
-  memberSince: 'January 2021',
-  bio: 'Weekend warrior and outdoor gear collector. I list items that still have plenty of adventures left in them.',
-}
-
-const metrics: ProfileMetric[] = [
-  { label: 'Active Listings', value: 6 },
-  { label: 'Items Sold', value: 42 },
-  { label: 'Response Rate', value: '98%' },
-  { label: 'Avg. Rating', value: '4.9/5' },
-]
-
-const activeListings: ProfileListingSummary[] = [
-  {
-    id: 'listing-1',
-    title: 'Carbon Road Bike - Medium Frame',
-    category: 'Cycling',
-    price: 1450,
-    currency: '$',
-    status: 'active',
-    updatedAt: '2 days ago',
-  },
-  {
-    id: 'listing-2',
-    title: 'Climbing Protection Set (12 pcs)',
-    category: 'Climbing',
-    price: 260,
-    currency: '$',
-    status: 'active',
-    updatedAt: '5 days ago',
-  },
-  {
-    id: 'listing-3',
-    title: 'Camping Cookware Kit',
-    category: 'Camping',
-    price: 75,
-    currency: '$',
-    status: 'draft',
-    updatedAt: '1 hour ago',
-  },
-]
-
-const savedItems: ProfileSavedItemSummary[] = [
-  {
-    id: 'saved-1',
-    title: 'Trail Running Backpack',
-    category: 'Running',
-    price: 95,
-    currency: '$',
-    favoritedAt: '3 days ago',
-  },
-  {
-    id: 'saved-2',
-    title: 'Inflatable Paddle Board',
-    category: 'Water Sports',
-    price: 320,
-    currency: '$',
-    favoritedAt: '1 week ago',
-  },
-]
-
-const preferenceToggles: ProfilePreferenceToggle[] = [
-  {
-    id: 'notifications-email',
-    label: 'Email Updates',
-    description: 'Receive a summary of new messages, offers, and shipping updates via email.',
-    enabled: true,
-  },
-  {
-    id: 'notifications-sms',
-    label: 'SMS Alerts',
-    description: 'Get a text message when buyers send new offers or questions.',
-    enabled: false,
-  },
-  {
-    id: 'notifications-push',
-    label: 'Push Notifications',
-    description: 'Be alerted instantly when an item sells or requires your attention.',
-    enabled: true,
-  },
-]
+import useProfile from '../hooks/useProfile'
+import type { ProfileAccountInfo } from '../types/profile'
 
 const Profile = () => {
   const { user, isHydrated } = useAuth()
+  const {
+    account: profileAccount,
+    metrics,
+    activeListings,
+    savedItems,
+    preferences,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useProfile({ enabled: Boolean(user) })
 
-  const accountDetails = useMemo<ProfileAccountInfo>(() => ({
-    ...account,
-    name: user?.name ?? account.name,
-    email: user?.email ?? account.email,
-  }), [user])
+  const accountDetails = useMemo<ProfileAccountInfo | undefined>(() => {
+    if (!user && !profileAccount) {
+      return undefined
+    }
+
+    if (!user) {
+      return profileAccount ?? undefined
+    }
+
+    const baseAccount: ProfileAccountInfo = {
+      name: user.name,
+      email: user.email,
+    }
+
+    if (!profileAccount) {
+      return baseAccount
+    }
+
+    return {
+      ...baseAccount,
+      ...profileAccount,
+      name: profileAccount.name ?? baseAccount.name,
+      email: profileAccount.email ?? baseAccount.email,
+    }
+  }, [profileAccount, user])
 
   if (!isHydrated) {
     return (
@@ -139,6 +80,7 @@ const Profile = () => {
       <ProfileHeader
         account={accountDetails}
         metrics={metrics}
+        isLoading={isLoading}
         actions={
           <button
             type="button"
@@ -148,18 +90,35 @@ const Profile = () => {
           </button>
         }
       />
+      {isError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <p>We couldn&apos;t load your profile details right now.</p>
+          {error?.message ? (
+            <p className="mt-1 text-xs text-red-600">{error.message}</p>
+          ) : null}
+          <button
+            type="button"
+            onClick={refetch}
+            className="mt-3 inline-flex items-center justify-center rounded-full border border-red-300 px-3 py-1 text-xs font-semibold text-red-700 transition hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={isLoading}
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
       <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
         <div className="flex flex-col gap-6">
-          <AccountInfoCard account={accountDetails} />
+          <AccountInfoCard account={accountDetails} isLoading={isLoading} />
           <ListingTable
             listings={activeListings}
             title="Active Listings"
             emptyMessage="You do not have any listings yet. Start by creating your first listing."
+            isLoading={isLoading}
           />
         </div>
         <div className="flex flex-col gap-6">
-          <SavedItemsCard items={savedItems} />
-          <PreferenceToggleList preferences={preferenceToggles} />
+          <SavedItemsCard items={savedItems} isLoading={isLoading} />
+          <PreferenceToggleList preferences={preferences} isLoading={isLoading} />
         </div>
       </div>
     </section>

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -1,0 +1,28 @@
+import { apiClient } from '../lib/apiClient'
+import type {
+  ProfileAccountInfo,
+  ProfileListingSummary,
+  ProfileMetric,
+  ProfilePreferenceToggle,
+  ProfileSavedItemSummary,
+} from '../types/profile'
+
+export const fetchProfileAccount = async () => {
+  return apiClient<ProfileAccountInfo | null>('/profile/account')
+}
+
+export const fetchProfileMetrics = async () => {
+  return apiClient<ProfileMetric[]>('/profile/metrics')
+}
+
+export const fetchProfileActiveListings = async () => {
+  return apiClient<ProfileListingSummary[]>('/profile/listings')
+}
+
+export const fetchProfileSavedItems = async () => {
+  return apiClient<ProfileSavedItemSummary[]>('/profile/saved-items')
+}
+
+export const fetchProfilePreferences = async () => {
+  return apiClient<ProfilePreferenceToggle[]>('/profile/preferences')
+}

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,8 +1,8 @@
 export interface ProfileAccountInfo {
-  name: string
-  email: string
+  name?: string
+  email?: string
   location?: string
-  memberSince: string
+  memberSince?: string
   bio?: string
 }
 


### PR DESCRIPTION
## Summary
- add a profile service and hook that load account, metrics, listings, saved items, and preferences for the signed-in user
- update the profile page to consume the hook alongside auth state so new accounts render empty states instead of seeded data
- refresh profile-related components and types to support optional data and loading placeholders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903a45ab910832b8079639fc7c0118e