### PR TITLE
feat: add tabbed profile dashboard with editable overview

### DIFF
--- a/frontend/src/components/profile/AccountInfoCard.tsx
+++ b/frontend/src/components/profile/AccountInfoCard.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react'
+import type { ReactNode } from 'react'
 import type { ProfileAccountInfo } from '../../types/profile'
 
 type AccountInfoCardProps = {
   account?: ProfileAccountInfo | null
   isLoading?: boolean
+  actions?: ReactNode
 }
 
-const AccountInfoCard = ({ account, isLoading = false }: AccountInfoCardProps) => {
+const AccountInfoCard = ({ account, isLoading = false, actions }: AccountInfoCardProps) => {
   const [isOpen, setIsOpen] = useState(true)
 
   const toggleVisibility = () => {
@@ -23,23 +25,27 @@ const AccountInfoCard = ({ account, isLoading = false }: AccountInfoCardProps) =
 
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <header className="flex items-center justify-between gap-2">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-slate-900">Account Information</h2>
           <p className="text-sm text-slate-500">
             Update your contact details and personal bio to help buyers know you better.
           </p>
         </div>
-        <button
-          type="button"
-          className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
-          onClick={toggleVisibility}
-          aria-expanded={isOpen}
-        >
-          {isOpen ? 'Hide' : 'Show'}
-          <span aria-hidden="true">▾</span>
-        </button>
+        <div className="flex items-center gap-2 md:self-start">
+          {actions ? <div className="hidden md:flex md:gap-2">{actions}</div> : null}
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 text-sm font-medium text-primary md:hidden"
+            onClick={toggleVisibility}
+            aria-expanded={isOpen}
+          >
+            {isOpen ? 'Hide' : 'Show'}
+            <span aria-hidden="true">▾</span>
+          </button>
+        </div>
       </header>
+      {actions ? <div className="mt-4 flex flex-wrap gap-2 md:hidden">{actions}</div> : null}
       <div
         className={`${
           isOpen ? 'mt-4 flex flex-col gap-4' : 'hidden'

--- a/frontend/src/components/profile/ProfileOverviewTab.tsx
+++ b/frontend/src/components/profile/ProfileOverviewTab.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import type { ChangeEvent, FormEvent } from 'react'
+import AccountInfoCard from './AccountInfoCard'
+import type { ProfileAccountInfo, ProfileAccountUpdateInput } from '../../types/profile'
+
+type ProfileOverviewTabProps = {
+  account?: ProfileAccountInfo | null
+  isLoading?: boolean
+  onUpdate: (input: ProfileAccountUpdateInput) => Promise<ProfileAccountInfo>
+  isUpdating?: boolean
+  updateError?: Error | null
+}
+
+type FormState = {
+  name: string
+  location: string
+  bio: string
+}
+
+const normalizeAccountToFormState = (account?: ProfileAccountInfo | null): FormState => ({
+  name: account?.name ?? '',
+  location: account?.location ?? '',
+  bio: account?.bio ?? '',
+})
+
+const ProfileOverviewTab = ({
+  account,
+  isLoading = false,
+  onUpdate,
+  isUpdating = false,
+  updateError,
+}: ProfileOverviewTabProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [formState, setFormState] = useState<FormState>(() => normalizeAccountToFormState(account))
+  const [localError, setLocalError] = useState<string | null>(null)
+  const [showSuccess, setShowSuccess] = useState(false)
+
+  const openEditor = () => {
+    setIsEditing(true)
+    setLocalError(null)
+    setShowSuccess(false)
+  }
+
+  const toggleEditing = () => {
+    setIsEditing((current) => {
+      const next = !current
+      if (next) {
+        setLocalError(null)
+        setShowSuccess(false)
+      }
+      return next
+    })
+  }
+
+  useEffect(() => {
+    setFormState(normalizeAccountToFormState(account))
+  }, [account])
+
+  useEffect(() => {
+    if (!updateError) {
+      return
+    }
+
+    setLocalError(updateError.message)
+  }, [updateError])
+
+  const onboardingPrompts = useMemo(() => {
+    const prompts: string[] = []
+
+    if (!account?.bio) {
+      prompts.push('Add a short bio so other members can learn more about you.')
+    }
+
+    if (!account?.location) {
+      prompts.push('Share your location to match with local buyers and sellers.')
+    }
+
+    if (!account?.name) {
+      prompts.push('Confirm your display name to personalize your storefront.')
+    }
+
+    return prompts
+  }, [account])
+
+  const handleInputChange = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { value } = event.target
+    setFormState((current) => ({ ...current, [field]: value }))
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLocalError(null)
+    setShowSuccess(false)
+
+    const payload: ProfileAccountUpdateInput = {
+      name: formState.name.trim() ? formState.name.trim() : undefined,
+      location: formState.location.trim() ? formState.location.trim() : undefined,
+      bio: formState.bio.trim() ? formState.bio.trim() : undefined,
+    }
+
+    try {
+      await onUpdate(payload)
+      setShowSuccess(true)
+      setIsEditing(false)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'We could not save your profile changes.'
+      setLocalError(message)
+    }
+  }
+
+  const handleCancel = () => {
+    setFormState(normalizeAccountToFormState(account))
+    setIsEditing(false)
+    setLocalError(null)
+    setShowSuccess(false)
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {showSuccess ? (
+        <div className="rounded-xl border border-green-200 bg-green-50 p-4 text-sm text-green-700">
+          Your profile information has been updated.
+        </div>
+      ) : null}
+      {localError ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {localError}
+        </div>
+      ) : null}
+      {!isLoading && onboardingPrompts.length > 0 ? (
+        <aside className="rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-4 text-sm text-primary">
+          <p className="font-semibold">Complete your profile</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {onboardingPrompts.map((prompt) => (
+              <li key={prompt}>{prompt}</li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="mt-3 inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            onClick={openEditor}
+            disabled={isUpdating}
+          >
+            Update profile
+          </button>
+        </aside>
+      ) : null}
+      <AccountInfoCard
+        account={account}
+        isLoading={isLoading}
+        actions={
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={toggleEditing}
+            disabled={isLoading || isUpdating}
+          >
+            {isEditing ? 'Close editor' : 'Edit profile'}
+          </button>
+        }
+      />
+      {isEditing ? (
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <fieldset className="grid gap-4" disabled={isUpdating}>
+            <legend className="text-base font-semibold text-slate-900">Edit your details</legend>
+            <div className="grid gap-2">
+              <label htmlFor="profile-name" className="text-sm font-medium text-slate-700">
+                Display name
+              </label>
+              <input
+                id="profile-name"
+                name="name"
+                type="text"
+                value={formState.name}
+                onChange={handleInputChange('name')}
+                autoComplete="name"
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                placeholder="Add your public display name"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="profile-location" className="text-sm font-medium text-slate-700">
+                Location
+              </label>
+              <input
+                id="profile-location"
+                name="location"
+                type="text"
+                value={formState.location}
+                onChange={handleInputChange('location')}
+                autoComplete="address-level2"
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                placeholder="City, Country"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="profile-bio" className="text-sm font-medium text-slate-700">
+                Bio
+              </label>
+              <textarea
+                id="profile-bio"
+                name="bio"
+                rows={5}
+                value={formState.bio}
+                onChange={handleInputChange('bio')}
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                placeholder="Share a brief introduction about your experience and what you offer."
+              />
+              <p className="text-xs text-slate-500">
+                Highlight your expertise, the types of items you trade, or anything that helps members trust you.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+                onClick={handleCancel}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isUpdating ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </fieldset>
+        </form>
+      ) : null}
+    </div>
+  )
+}
+
+export default ProfileOverviewTab

--- a/frontend/src/components/profile/ProfileTabs.tsx
+++ b/frontend/src/components/profile/ProfileTabs.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+import type { KeyboardEvent } from 'react'
+
+export type ProfileTabConfig = {
+  id: string
+  label: string
+}
+
+type ProfileTabsProps = {
+  tabs: ProfileTabConfig[]
+  activeTabId: string
+  onTabChange: (tabId: string) => void
+  ariaLabel?: string
+  baseId?: string
+}
+
+const ProfileTabs = ({
+  tabs,
+  activeTabId,
+  onTabChange,
+  ariaLabel = 'Profile sections',
+  baseId = 'profile-tabs',
+}: ProfileTabsProps) => {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  useEffect(() => {
+    if (!tabs.some((tab) => tab.id === activeTabId) && tabs.length > 0) {
+      onTabChange(tabs[0].id)
+    }
+  }, [activeTabId, onTabChange, tabs])
+
+  const focusTabAtIndex = (index: number) => {
+    const clampedIndex = (index + tabs.length) % tabs.length
+    const targetRef = tabRefs.current[clampedIndex]
+
+    if (targetRef) {
+      targetRef.focus()
+    }
+
+    const targetTab = tabs[clampedIndex]
+    if (targetTab) {
+      onTabChange(targetTab.id)
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (tabs.length === 0) {
+      return
+    }
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown': {
+        event.preventDefault()
+        focusTabAtIndex(index + 1)
+        break
+      }
+      case 'ArrowLeft':
+      case 'ArrowUp': {
+        event.preventDefault()
+        focusTabAtIndex(index - 1)
+        break
+      }
+      case 'Home': {
+        event.preventDefault()
+        focusTabAtIndex(0)
+        break
+      }
+      case 'End': {
+        event.preventDefault()
+        focusTabAtIndex(tabs.length - 1)
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        event.preventDefault()
+        const targetTab = tabs[index]
+        if (targetTab) {
+          onTabChange(targetTab.id)
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200 bg-white p-2 shadow-sm"
+    >
+      {tabs.map((tab, index) => {
+        const isActive = tab.id === activeTabId
+        const tabId = `${baseId}-tab-${tab.id}`
+        const panelId = `${baseId}-panel-${tab.id}`
+        const baseClasses =
+          'inline-flex items-center rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary'
+        const activeClasses = 'bg-primary text-white shadow-sm'
+        const inactiveClasses =
+          'border border-slate-200 bg-white text-slate-600 hover:border-primary/40 hover:text-slate-900'
+
+        return (
+          <button
+            key={tab.id}
+            ref={(element) => {
+              tabRefs.current[index] = element
+            }}
+            type="button"
+            role="tab"
+            id={tabId}
+            aria-selected={isActive}
+            aria-controls={panelId}
+            tabIndex={isActive ? 0 : -1}
+            className={`${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
+            onClick={() => onTabChange(tab.id)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ProfileTabs

--- a/frontend/src/components/profile/ReputationPanel.tsx
+++ b/frontend/src/components/profile/ReputationPanel.tsx
@@ -1,0 +1,48 @@
+import type { ProfileMetric } from '../../types/profile'
+
+type ReputationPanelProps = {
+  metrics: ProfileMetric[]
+  isLoading?: boolean
+}
+
+const ReputationPanel = ({ metrics, isLoading = false }: ReputationPanelProps) => {
+  const hasMetrics = metrics.length > 0
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-slate-900">Reputation &amp; Community Trust</h2>
+        <p className="text-sm text-slate-500">
+          Track how the community sees you and learn ways to grow your marketplace presence.
+        </p>
+      </header>
+      {isLoading ? (
+        <p className="mt-4 text-sm text-slate-500">Loading your reputation insights…</p>
+      ) : hasMetrics ? (
+        <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-center">
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{metric.label}</dt>
+              <dd className="mt-2 text-2xl font-semibold text-slate-900">{metric.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="mt-4 text-sm text-slate-500">
+          You haven&apos;t built up reputation metrics yet. Complete listings, respond quickly, and gather reviews to grow your
+          presence.
+        </p>
+      )}
+      <div className="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        <p className="font-semibold">Tips to grow your reputation</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>Respond to inquiries within a day to maintain a reliable response rate.</li>
+          <li>Keep your listings accurate and updated before accepting offers.</li>
+          <li>Request feedback after successful trades to showcase positive experiences.</li>
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+export default ReputationPanel

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -7,9 +7,11 @@ import {
   fetchProfileMetrics,
   fetchProfilePreferences,
   fetchProfileSavedItems,
+  updateProfileAccount,
 } from '../services/profile'
 import type {
   ProfileAccountInfo,
+  ProfileAccountUpdateInput,
   ProfileListingSummary,
   ProfileMetric,
   ProfilePreferenceToggle,
@@ -33,6 +35,9 @@ type UseProfileState = ProfileData & {
   isError: boolean
   error: Error | null
   refetch: () => Promise<void>
+  updateAccount: (input: ProfileAccountUpdateInput) => Promise<ProfileAccountInfo>
+  isUpdatingAccount: boolean
+  updateAccountError: Error | null
 }
 
 const EMPTY_PROFILE_DATA: ProfileData = {
@@ -65,6 +70,8 @@ export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfi
   const [data, setData] = useState<ProfileData>(EMPTY_PROFILE_DATA)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const [isUpdatingAccount, setIsUpdatingAccount] = useState(false)
+  const [updateAccountError, setUpdateAccountError] = useState<Error | null>(null)
 
   const loadProfile = useCallback(async () => {
     if (!enabled) {
@@ -105,6 +112,32 @@ export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfi
     }
   }, [enabled])
 
+  const updateAccount = useCallback(async (input: ProfileAccountUpdateInput) => {
+    setIsUpdatingAccount(true)
+    setUpdateAccountError(null)
+
+    try {
+      const updatedAccount = await updateProfileAccount(input)
+
+      setData((current) => ({
+        ...current,
+        account: current.account ? { ...current.account, ...updatedAccount } : updatedAccount,
+      }))
+
+      return updatedAccount
+    } catch (error) {
+      const normalizedError =
+        error instanceof Error
+          ? error
+          : new Error('We could not update your profile details. Please try again later.')
+
+      setUpdateAccountError(normalizedError)
+      throw normalizedError
+    } finally {
+      setIsUpdatingAccount(false)
+    }
+  }, [])
+
   useEffect(() => {
     loadProfile()
   }, [loadProfile])
@@ -116,8 +149,11 @@ export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfi
       isError: Boolean(error),
       error,
       refetch: loadProfile,
+      updateAccount,
+      isUpdatingAccount,
+      updateAccountError,
     }),
-    [data, error, isLoading, loadProfile],
+    [data, error, isLoading, loadProfile, updateAccount, isUpdatingAccount, updateAccountError],
   )
 }
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,14 +1,24 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 
-import AccountInfoCard from '../components/profile/AccountInfoCard'
 import ListingTable from '../components/profile/ListingTable'
 import PreferenceToggleList from '../components/profile/PreferenceToggleList'
 import ProfileHeader from '../components/profile/ProfileHeader'
+import ProfileOverviewTab from '../components/profile/ProfileOverviewTab'
+import ProfileTabs, { type ProfileTabConfig } from '../components/profile/ProfileTabs'
+import ReputationPanel from '../components/profile/ReputationPanel'
 import SavedItemsCard from '../components/profile/SavedItemsCard'
 import { useAuth } from '../context/useAuth'
 import useProfile from '../hooks/useProfile'
 import type { ProfileAccountInfo } from '../types/profile'
+
+const PROFILE_TABS: ProfileTabConfig[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'listings', label: 'Listings' },
+  { id: 'saved', label: 'Saved Items' },
+  { id: 'preferences', label: 'Preferences' },
+  { id: 'reputation', label: 'Reputation' },
+]
 
 const Profile = () => {
   const { user, isHydrated } = useAuth()
@@ -22,7 +32,12 @@ const Profile = () => {
     isError,
     error,
     refetch,
+    updateAccount,
+    isUpdatingAccount,
+    updateAccountError,
   } = useProfile({ enabled: Boolean(user) })
+
+  const [activeTab, setActiveTab] = useState<string>(PROFILE_TABS[0]?.id ?? 'overview')
 
   const accountDetails = useMemo<ProfileAccountInfo | undefined>(() => {
     if (!user && !profileAccount) {
@@ -75,6 +90,54 @@ const Profile = () => {
     )
   }
 
+  const renderActiveTab = () => {
+    switch (activeTab) {
+      case 'listings':
+        return (
+          <div className="flex flex-col gap-6">
+            <ListingTable
+              listings={activeListings}
+              title="Active Listings"
+              emptyMessage="You do not have any listings yet. Start by creating your first listing."
+              isLoading={isLoading}
+            />
+          </div>
+        )
+      case 'saved':
+        return (
+          <div className="flex flex-col gap-6">
+            <SavedItemsCard items={savedItems} isLoading={isLoading} />
+          </div>
+        )
+      case 'preferences':
+        return (
+          <div className="flex flex-col gap-6">
+            <PreferenceToggleList preferences={preferences} isLoading={isLoading} />
+          </div>
+        )
+      case 'reputation':
+        return <ReputationPanel metrics={metrics} isLoading={isLoading} />
+      case 'overview':
+      default:
+        return (
+          <ProfileOverviewTab
+            account={accountDetails}
+            isLoading={isLoading}
+            onUpdate={updateAccount}
+            isUpdating={isUpdatingAccount}
+            updateError={updateAccountError}
+          />
+        )
+    }
+  }
+
+  const activeTabId = PROFILE_TABS.some((tab) => tab.id === activeTab)
+    ? activeTab
+    : PROFILE_TABS[0]?.id ?? 'overview'
+  const baseTabId = 'profile-dashboard'
+  const panelId = `${baseTabId}-panel-${activeTabId}`
+  const tabId = `${baseTabId}-tab-${activeTabId}`
+
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 lg:px-0">
       <ProfileHeader
@@ -106,20 +169,19 @@ const Profile = () => {
           </button>
         </div>
       ) : null}
-      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-        <div className="flex flex-col gap-6">
-          <AccountInfoCard account={accountDetails} isLoading={isLoading} />
-          <ListingTable
-            listings={activeListings}
-            title="Active Listings"
-            emptyMessage="You do not have any listings yet. Start by creating your first listing."
-            isLoading={isLoading}
-          />
-        </div>
-        <div className="flex flex-col gap-6">
-          <SavedItemsCard items={savedItems} isLoading={isLoading} />
-          <PreferenceToggleList preferences={preferences} isLoading={isLoading} />
-        </div>
+      <ProfileTabs
+        tabs={PROFILE_TABS}
+        activeTabId={activeTabId}
+        onTabChange={setActiveTab}
+        baseId={baseTabId}
+      />
+      <div
+        role="tabpanel"
+        id={panelId}
+        aria-labelledby={tabId}
+        className="mt-2"
+      >
+        {renderActiveTab()}
       </div>
     </section>
   )

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '../lib/apiClient'
 import type {
   ProfileAccountInfo,
+  ProfileAccountUpdateInput,
   ProfileListingSummary,
   ProfileMetric,
   ProfilePreferenceToggle,
@@ -25,4 +26,11 @@ export const fetchProfileSavedItems = async () => {
 
 export const fetchProfilePreferences = async () => {
   return apiClient<ProfilePreferenceToggle[]>('/profile/preferences')
+}
+
+export const updateProfileAccount = async (input: ProfileAccountUpdateInput) => {
+  return apiClient<ProfileAccountInfo>('/profile/account', {
+    method: 'PATCH',
+    body: input,
+  })
 }

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -6,6 +6,12 @@ export interface ProfileAccountInfo {
   bio?: string
 }
 
+export interface ProfileAccountUpdateInput {
+  name?: string
+  location?: string
+  bio?: string
+}
+
 export interface ProfileListingSummary {
   id: string
   title: string


### PR DESCRIPTION
## Summary
- add a keyboard-accessible tab bar to the profile dashboard that switches between overview, listings, saved items, preferences, and reputation
- build an editable overview experience with onboarding prompts that updates profile details through the profile data hook
- extend the profile services with account update support and add a reputation guidance panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6903a6377b48832b85c3081a6412bbfb