### PR TITLE
Add profile listings tab with filtering

### DIFF
--- a/frontend/src/components/profile/ListingTable.tsx
+++ b/frontend/src/components/profile/ListingTable.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import type { ProfileListingSummary } from '../../types/profile'
+import type { ProfileListingWithActions } from '../../types/profile'
 
 type ListingTableProps = {
-  listings: ProfileListingSummary[]
+  listings: ProfileListingWithActions[]
   title: string
   emptyMessage?: string
   isLoading?: boolean
@@ -53,6 +53,7 @@ const ListingTable = ({ listings, title, emptyMessage, isLoading = false }: List
                   <th className="px-3 py-2">Price</th>
                   <th className="px-3 py-2">Status</th>
                   <th className="px-3 py-2">Updated</th>
+                  <th className="px-3 py-2 text-right">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 text-sm text-slate-700">
@@ -66,6 +67,24 @@ const ListingTable = ({ listings, title, emptyMessage, isLoading = false }: List
                     </td>
                     <td className="px-3 py-3 capitalize">{listing.status}</td>
                     <td className="px-3 py-3 text-slate-500">{listing.updatedAt}</td>
+                    <td className="px-3 py-3">
+                      <div className="flex items-center justify-end gap-2 text-sm">
+                        <a
+                          href={listing.actions.editUrl}
+                          className="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-primary/40 hover:text-primary"
+                        >
+                          Edit
+                        </a>
+                        {listing.actions.archiveUrl ? (
+                          <a
+                            href={listing.actions.archiveUrl}
+                            className="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-red-200 hover:text-red-600"
+                          >
+                            Archive
+                          </a>
+                        ) : null}
+                      </div>
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -99,6 +118,22 @@ const ListingTable = ({ listings, title, emptyMessage, isLoading = false }: List
                     <dd>{listing.updatedAt}</dd>
                   </div>
                 </dl>
+                <div className="mt-4 flex flex-wrap items-center gap-2 text-xs font-medium">
+                  <a
+                    href={listing.actions.editUrl}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:border-primary/40 hover:text-primary"
+                  >
+                    Edit listing
+                  </a>
+                  {listing.actions.archiveUrl ? (
+                    <a
+                      href={listing.actions.archiveUrl}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-200 px-3 py-1 text-slate-600 transition hover:border-red-200 hover:text-red-600"
+                    >
+                      Archive
+                    </a>
+                  ) : null}
+                </div>
               </article>
             ))}
           </div>

--- a/frontend/src/components/profile/ProfileListingsTab.tsx
+++ b/frontend/src/components/profile/ProfileListingsTab.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import ListingTable from './ListingTable'
+import type {
+  ProfileListingStatusGroup,
+  ProfileListingsOverview,
+} from '../../types/profile'
+
+type ProfileListingsTabProps = {
+  listings: ProfileListingsOverview
+  isLoading?: boolean
+}
+
+type StatusFilterOption = {
+  id: 'all' | ProfileListingStatusGroup['id']
+  label: string
+  count: number
+}
+
+const DEFAULT_CREATE_URL = '/listings/new'
+
+const ProfileListingsTab = ({ listings, isLoading = false }: ProfileListingsTabProps) => {
+  const groups = listings.groups ?? []
+  const [activeFilter, setActiveFilter] = useState<StatusFilterOption['id']>('all')
+  const createListingUrl = listings.createListingUrl ?? DEFAULT_CREATE_URL
+
+  useEffect(() => {
+    if (activeFilter === 'all') {
+      return
+    }
+
+    const hasActiveFilter = groups.some((group) => group.id === activeFilter)
+
+    if (!hasActiveFilter) {
+      setActiveFilter(groups[0]?.id ?? 'all')
+    }
+  }, [activeFilter, groups])
+
+  const totalListings = useMemo(
+    () => groups.reduce((total, group) => total + group.listings.length, 0),
+    [groups],
+  )
+
+  const filterOptions = useMemo<StatusFilterOption[]>(
+    () => [
+      { id: 'all', label: 'All', count: totalListings },
+      ...groups.map((group) => ({ id: group.id, label: group.label, count: group.listings.length })),
+    ],
+    [groups, totalListings],
+  )
+
+  const filteredListings = useMemo(() => {
+    if (activeFilter === 'all') {
+      return groups.flatMap((group) => group.listings)
+    }
+
+    return groups.find((group) => group.id === activeFilter)?.listings ?? []
+  }, [activeFilter, groups])
+
+  const activeGroup = useMemo(() => {
+    if (activeFilter === 'all') {
+      return undefined
+    }
+
+    return groups.find((group) => group.id === activeFilter)
+  }, [activeFilter, groups])
+
+  const hasAnyListings = totalListings > 0
+  const shouldShowTable = filteredListings.length > 0 || isLoading
+
+  const emptyTitle = activeGroup?.emptyState?.title ?? (hasAnyListings ? 'No listings for this status' : 'No listings yet')
+  const emptyDescription =
+    activeGroup?.emptyState?.description ??
+    (hasAnyListings
+      ? 'You have no listings that match this status. Try selecting a different filter or creating a new listing.'
+      : 'Create your first listing to start reaching buyers on Olymarket.')
+  const emptyAction = activeGroup?.emptyState?.action
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Listings</h2>
+          <p className="text-sm text-slate-600">
+            {activeGroup?.description ?? 'Manage and organize all of your listings from a single place.'}
+          </p>
+        </div>
+        <a
+          href={createListingUrl}
+          className="inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+        >
+          Create listing
+        </a>
+      </header>
+
+      <div className="mt-6 flex flex-wrap items-center gap-2">
+        {filterOptions.map((option) => {
+          const isActive = option.id === activeFilter
+          const baseClasses =
+            'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary'
+          const activeClasses = 'border-transparent bg-primary text-white shadow-sm'
+          const inactiveClasses = 'border-slate-200 text-slate-600 hover:border-primary/40 hover:text-slate-900'
+
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setActiveFilter(option.id)}
+              className={`${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
+            >
+              <span>{option.label}</span>
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600">
+                {option.count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {shouldShowTable ? (
+        <div className="mt-6">
+          <ListingTable
+            listings={filteredListings}
+            title={activeFilter === 'all' ? 'All Listings' : `${activeGroup?.label ?? 'Listings'}`}
+            emptyMessage={emptyDescription}
+            isLoading={isLoading}
+          />
+        </div>
+      ) : (
+        <div className="mt-10 flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-10 text-center">
+          <h3 className="text-lg font-semibold text-slate-900">{emptyTitle}</h3>
+          <p className="max-w-md text-sm text-slate-600">{emptyDescription}</p>
+          <a
+            href={emptyAction?.url ?? createListingUrl}
+            className="inline-flex items-center justify-center rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary hover:text-white"
+          >
+            {emptyAction?.label ?? 'Create your first listing'}
+          </a>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export default ProfileListingsTab

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ApiError } from '../lib/apiClient'
 import {
   fetchProfileAccount,
-  fetchProfileActiveListings,
+  fetchProfileListings,
   fetchProfileMetrics,
   fetchProfilePreferences,
   fetchProfileSavedItems,
@@ -12,7 +12,7 @@ import {
 import type {
   ProfileAccountInfo,
   ProfileAccountUpdateInput,
-  ProfileListingSummary,
+  ProfileListingsOverview,
   ProfileMetric,
   ProfilePreferenceToggle,
   ProfileSavedItemSummary,
@@ -21,7 +21,7 @@ import type {
 type ProfileData = {
   account: ProfileAccountInfo | null
   metrics: ProfileMetric[]
-  activeListings: ProfileListingSummary[]
+  listings: ProfileListingsOverview
   savedItems: ProfileSavedItemSummary[]
   preferences: ProfilePreferenceToggle[]
 }
@@ -43,7 +43,7 @@ type UseProfileState = ProfileData & {
 const EMPTY_PROFILE_DATA: ProfileData = {
   account: null,
   metrics: [],
-  activeListings: [],
+  listings: { groups: [], createListingUrl: undefined },
   savedItems: [],
   preferences: [],
 }
@@ -84,10 +84,13 @@ export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfi
     setError(null)
 
     try {
-      const [account, metrics, activeListings, savedItems, preferences] = await Promise.all([
+      const [account, metrics, listings, savedItems, preferences] = await Promise.all([
         resolveOrFallback<ProfileAccountInfo | null>(fetchProfileAccount, null),
         resolveOrFallback<ProfileMetric[]>(fetchProfileMetrics, []),
-        resolveOrFallback<ProfileListingSummary[]>(fetchProfileActiveListings, []),
+        resolveOrFallback<ProfileListingsOverview>(fetchProfileListings, {
+          groups: [],
+          createListingUrl: undefined,
+        }),
         resolveOrFallback<ProfileSavedItemSummary[]>(fetchProfileSavedItems, []),
         resolveOrFallback<ProfilePreferenceToggle[]>(fetchProfilePreferences, []),
       ])
@@ -95,7 +98,7 @@ export const useProfile = ({ enabled = true }: UseProfileOptions = {}): UseProfi
       setData({
         account,
         metrics,
-        activeListings,
+        listings,
         savedItems,
         preferences,
       })

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 
-import ListingTable from '../components/profile/ListingTable'
 import PreferenceToggleList from '../components/profile/PreferenceToggleList'
 import ProfileHeader from '../components/profile/ProfileHeader'
 import ProfileOverviewTab from '../components/profile/ProfileOverviewTab'
+import ProfileListingsTab from '../components/profile/ProfileListingsTab'
 import ProfileTabs, { type ProfileTabConfig } from '../components/profile/ProfileTabs'
 import ReputationPanel from '../components/profile/ReputationPanel'
 import SavedItemsCard from '../components/profile/SavedItemsCard'
@@ -25,7 +25,7 @@ const Profile = () => {
   const {
     account: profileAccount,
     metrics,
-    activeListings,
+    listings,
     savedItems,
     preferences,
     isLoading,
@@ -65,6 +65,8 @@ const Profile = () => {
     }
   }, [profileAccount, user])
 
+  const createListingUrl = listings.createListingUrl ?? '/listings/new'
+
   if (!isHydrated) {
     return (
       <section className="mx-auto flex w-full max-w-4xl flex-col items-center justify-center px-4 py-24 text-slate-500">
@@ -95,12 +97,7 @@ const Profile = () => {
       case 'listings':
         return (
           <div className="flex flex-col gap-6">
-            <ListingTable
-              listings={activeListings}
-              title="Active Listings"
-              emptyMessage="You do not have any listings yet. Start by creating your first listing."
-              isLoading={isLoading}
-            />
+            <ProfileListingsTab listings={listings} isLoading={isLoading} />
           </div>
         )
       case 'saved':
@@ -145,12 +142,12 @@ const Profile = () => {
         metrics={metrics}
         isLoading={isLoading}
         actions={
-          <button
-            type="button"
+          <a
+            href={createListingUrl}
             className="inline-flex items-center justify-center rounded-full border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary hover:text-white"
           >
             Create Listing
-          </button>
+          </a>
         }
       />
       {isError ? (

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -2,7 +2,7 @@ import { apiClient } from '../lib/apiClient'
 import type {
   ProfileAccountInfo,
   ProfileAccountUpdateInput,
-  ProfileListingSummary,
+  ProfileListingsOverview,
   ProfileMetric,
   ProfilePreferenceToggle,
   ProfileSavedItemSummary,
@@ -16,8 +16,8 @@ export const fetchProfileMetrics = async () => {
   return apiClient<ProfileMetric[]>('/profile/metrics')
 }
 
-export const fetchProfileActiveListings = async () => {
-  return apiClient<ProfileListingSummary[]>('/profile/listings')
+export const fetchProfileListings = async () => {
+  return apiClient<ProfileListingsOverview>('/profile/listings')
 }
 
 export const fetchProfileSavedItems = async () => {

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -12,15 +12,51 @@ export interface ProfileAccountUpdateInput {
   bio?: string
 }
 
+export type ProfileListingStatus = 'active' | 'sold' | 'draft'
+
 export interface ProfileListingSummary {
   id: string
   title: string
   category: string
   price: number
   currency: string
-  status: 'active' | 'sold' | 'draft'
+  status: ProfileListingStatus
   updatedAt: string
   thumbnailUrl?: string
+}
+
+export interface ProfileListingActionLinks {
+  editUrl: string
+  archiveUrl?: string
+  viewUrl?: string
+}
+
+export interface ProfileListingWithActions extends ProfileListingSummary {
+  actions: ProfileListingActionLinks
+}
+
+export interface ProfileListingStatusEmptyStateAction {
+  label: string
+  url: string
+}
+
+export interface ProfileListingStatusEmptyState {
+  title: string
+  description: string
+  action?: ProfileListingStatusEmptyStateAction
+}
+
+export interface ProfileListingStatusGroup {
+  id: ProfileListingStatus
+  label: string
+  description?: string
+  listings: ProfileListingWithActions[]
+  emptyState?: ProfileListingStatusEmptyState
+}
+
+export interface ProfileListingsOverview {
+  groups: ProfileListingStatusGroup[]
+  createListingUrl?: string
 }
 
 export interface ProfileSavedItemSummary {


### PR DESCRIPTION
## Summary
- introduce a dedicated profile listings tab that surfaces grouped listings with status filters and empty states
- expand the profile service, hook, and types to return listings metadata and action URLs
- update the listing table to expose edit/archive controls and wire the tab into the profile page header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903a8983a24832b899ace90542570e1