### PR TITLE
Enhance frontend auth state with moderation metadata

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,12 +45,47 @@ const RequireAuth = ({ children }: { children: ReactElement }) => {
 }
 
 const App = () => {
-  const { user, logout, isHydrated } = useAuth()
+  const { user, logout, isHydrated, isAdmin, isModerator, banNotice, clearBanNotice } =
+    useAuth()
   const userInitial = (user?.name || user?.email || '').charAt(0).toUpperCase()
 
   return (
     <BrowserRouter>
       <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+        {banNotice ? (
+          <div className="border-b border-amber-200 bg-amber-50">
+            <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-3 text-sm text-amber-800 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="font-semibold">Account suspended</p>
+                <p>
+                  {banNotice.reason
+                    ? `Your marketplace access is limited: ${banNotice.reason}`
+                    : 'Your marketplace access is currently limited by our moderators.'}
+                </p>
+                {banNotice.banExpiresAt ? (
+                  <p className="text-xs text-amber-700">
+                    Suspension details: {banNotice.banExpiresAt}
+                  </p>
+                ) : null}
+                {banNotice.appealUrl ? (
+                  <a
+                    href={banNotice.appealUrl}
+                    className="mt-1 inline-flex text-xs font-semibold underline-offset-2 hover:underline"
+                  >
+                    Contact support to appeal
+                  </a>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={clearBanNotice}
+                className="self-start rounded-full border border-amber-300 px-3 py-1 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        ) : null}
         <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
           <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
             <NavLink to="/" className="text-2xl font-semibold tracking-tight text-primary">
@@ -81,11 +116,16 @@ const App = () => {
                     <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary transition group-hover:bg-primary group-hover:text-white">
                       {userInitial || '?'}
                     </span>
-                    <span className="text-slate-700 group-hover:text-primary">{user.name}</span>
+                    <span className="flex flex-col text-left text-slate-700 group-hover:text-primary">
+                      <span>{user.name}</span>
+                      <span className="text-xs font-semibold text-slate-400 group-hover:text-primary/80">
+                        {isAdmin ? 'Admin' : isModerator ? 'Moderator' : 'Member'}
+                      </span>
+                    </span>
                   </NavLink>
                   <button
                     type="button"
-                    onClick={logout}
+                    onClick={() => logout()}
                     className="rounded-full px-3 py-1 text-slate-600 transition-colors hover:bg-slate-100"
                   >
                     Sign Out

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -12,6 +12,9 @@ const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions,
   const displayName = account?.name ?? (isLoading ? 'Loading profile…' : 'Your profile')
   const displayEmail = account?.email
   const hasMetrics = metrics.length > 0
+  const roleLabel = account?.role
+    ? account.role.charAt(0).toUpperCase() + account.role.slice(1)
+    : undefined
 
   return (
     <header className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -19,6 +22,11 @@ const ProfileHeader: FC<ProfileHeaderProps> = ({ account, metrics = [], actions,
         <div>
           <p className="text-sm font-semibold uppercase tracking-wide text-primary">Dashboard</p>
           <h1 className="text-3xl font-semibold text-slate-900">{displayName}</h1>
+          {roleLabel ? (
+            <span className="mt-2 inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+              {roleLabel}
+            </span>
+          ) : null}
           {displayEmail ? (
             <p className="mt-1 text-sm text-slate-600">{displayEmail}</p>
           ) : null}

--- a/frontend/src/context/AuthContext.shared.ts
+++ b/frontend/src/context/AuthContext.shared.ts
@@ -1,13 +1,26 @@
 import { createContext } from "react"
 import { type AuthResponse, type AuthUser } from "../types/auth"
 
+export type BannedAccountNotice = {
+  isBanned: true
+  reason?: string | null
+  bannedAt?: string | null
+  banExpiresAt?: string | null
+  appealUrl?: string | null
+}
+
 export type AuthContextValue = {
   user: AuthUser | null
   token: string | null
   isHydrated: boolean
+  isAdmin: boolean
+  isModerator: boolean
+  isBanned: boolean
+  banNotice: BannedAccountNotice | null
   login: (auth: AuthResponse) => void
-  logout: () => void
+  logout: (options?: { preserveBanNotice?: boolean }) => void
   refreshSession: () => Promise<AuthUser | null>
+  clearBanNotice: () => void
 }
 
 export const AuthContext = createContext<AuthContextValue | undefined>(undefined)

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
 import { subscribeToUnauthorized, unsubscribeFromUnauthorized } from "../lib/authEvents"
 import { refreshSessionRequest } from "../services/auth"
 import { type AuthResponse, type AuthUser } from "../types/auth"
-import { AuthContext } from "./AuthContext.shared"
+import { AuthContext, type BannedAccountNotice } from "./AuthContext.shared"
 import { persistAuth, readStoredAuth, type StoredAuth } from "./authStorage"
 
 type AuthProviderProps = {
@@ -22,21 +22,60 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
   const [user, setUser] = useState<AuthUser | null>(initialAuth?.user ?? null)
   const [token, setToken] = useState<string | null>(initialAuth?.token ?? null)
   const [isHydrated, setIsHydrated] = useState<boolean>(Boolean(initialAuth))
+  const [banNotice, setBanNotice] = useState<BannedAccountNotice | null>(null)
   const hasAttemptedRefresh = useRef(false)
 
-  const login = useCallback((auth: AuthResponse) => {
-    setUser(auth.user)
-    setToken(auth.token)
-    persistAuth(auth)
-    setIsHydrated(true)
-  }, [])
-
-  const logout = useCallback(() => {
+  const resetAuthState = useCallback(() => {
     setUser(null)
     setToken(null)
     persistAuth(null)
-    setIsHydrated(true)
   }, [])
+
+  const clearBanNotice = useCallback(() => {
+    setBanNotice(null)
+  }, [])
+
+  const logout = useCallback(
+    (options?: { preserveBanNotice?: boolean }) => {
+      resetAuthState()
+      if (!options?.preserveBanNotice) {
+        clearBanNotice()
+      }
+      setIsHydrated(true)
+    },
+    [clearBanNotice, resetAuthState]
+  )
+
+  const applyBannedState = useCallback(
+    (bannedUser: AuthUser) => {
+      setBanNotice({
+        isBanned: true,
+        reason: bannedUser.banReason ?? bannedUser.moderation?.notes ?? null,
+        bannedAt: bannedUser.moderation?.bannedAt ?? null,
+        banExpiresAt: bannedUser.moderation?.banExpiresAt ?? null,
+        appealUrl: bannedUser.moderation?.appealUrl ?? null,
+      })
+      resetAuthState()
+      setIsHydrated(true)
+    },
+    [resetAuthState]
+  )
+
+  const login = useCallback(
+    (auth: AuthResponse) => {
+      if (auth.user.isBanned) {
+        applyBannedState(auth.user)
+        return
+      }
+
+      setUser(auth.user)
+      setToken(auth.token)
+      clearBanNotice()
+      persistAuth(auth)
+      setIsHydrated(true)
+    },
+    [applyBannedState, clearBanNotice]
+  )
 
   const refreshSession = useCallback(async () => {
     if (!token) {
@@ -46,8 +85,15 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
 
     try {
       const currentUser = await refreshSessionRequest()
+
+      if (currentUser.isBanned) {
+        applyBannedState(currentUser)
+        return null
+      }
+
       const nextAuth: StoredAuth = { user: currentUser, token }
       setUser(currentUser)
+      clearBanNotice()
       persistAuth(nextAuth)
       setIsHydrated(true)
       return currentUser
@@ -55,19 +101,24 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
       logout()
       throw error
     }
-  }, [logout, token])
+  }, [applyBannedState, logout, token])
 
   useEffect(() => {
     if (!hasAttemptedRefresh.current) {
       hasAttemptedRefresh.current = true
       const stored = initialAuth ?? readStoredAuth()
       if (stored && (!user || !token)) {
-        setUser(stored.user)
-        setToken(stored.token)
+        if (stored.user.isBanned) {
+          applyBannedState(stored.user)
+        } else {
+          setUser(stored.user)
+          setToken(stored.token)
+          clearBanNotice()
+        }
       }
       refreshSession().catch(() => undefined)
     }
-  }, [initialAuth, refreshSession, token, user])
+  }, [applyBannedState, clearBanNotice, initialAuth, refreshSession, token, user])
 
   useEffect(() => {
     const handleUnauthorized = () => {
@@ -85,11 +136,16 @@ export const AuthProvider = ({ children, initialAuth }: AuthProviderProps) => {
       user,
       token,
       isHydrated,
+      isAdmin: user?.role === "admin",
+      isModerator: user?.role === "admin" || user?.role === "moderator",
+      isBanned: Boolean(user?.isBanned || banNotice?.isBanned),
+      banNotice,
       login,
       logout,
       refreshSession,
+      clearBanNotice,
     }),
-    [isHydrated, login, logout, refreshSession, token, user]
+    [banNotice, clearBanNotice, isHydrated, login, logout, refreshSession, token, user]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/context/authStorage.ts
+++ b/frontend/src/context/authStorage.ts
@@ -5,6 +5,27 @@ const STORAGE_KEY = "olymarket.auth"
 
 export type StoredAuth = AuthResponse
 
+const isValidStoredAuth = (value: unknown): value is StoredAuth => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const maybe = value as Partial<StoredAuth>
+  const maybeUser = maybe?.user as Partial<StoredAuth["user"]> | undefined
+
+  if (!maybeUser || typeof maybe?.token !== "string") {
+    return false
+  }
+
+  return (
+    typeof maybeUser.id === "number" &&
+    typeof maybeUser.email === "string" &&
+    typeof maybeUser.name === "string" &&
+    typeof maybeUser.role === "string" &&
+    typeof maybeUser.isBanned === "boolean"
+  )
+}
+
 export const readStoredAuth = (): StoredAuth | null => {
   if (typeof window === "undefined") {
     return null
@@ -13,13 +34,15 @@ export const readStoredAuth = (): StoredAuth | null => {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     if (!raw) return null
-    const parsed = JSON.parse(raw) as StoredAuth
-    if (!parsed?.user || !parsed?.token) return null
+    const parsed = JSON.parse(raw)
+    if (!isValidStoredAuth(parsed)) return null
+
+    const storedAuth = parsed as StoredAuth
     const storedToken = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
-    if (!storedToken || storedToken !== parsed.token) {
-      window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, parsed.token)
+    if (!storedToken || storedToken !== storedAuth.token) {
+      window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, storedAuth.token)
     }
-    return parsed
+    return storedAuth
   } catch (error) {
     console.warn("Failed to parse stored auth", error)
     return null

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -126,7 +126,7 @@ const Auth = () => {
   const [showRegisterPassword, setShowRegisterPassword] = useState(false)
   const [showRegisterConfirmPassword, setShowRegisterConfirmPassword] =
     useState(false)
-  const { login: setAuth } = useAuth()
+  const { login: setAuth, banNotice } = useAuth()
 
   const loginForm = useFormValidation(
     { email: "", password: "" },
@@ -197,7 +197,23 @@ const Auth = () => {
       loginForm.setStatus("success", "Welcome back! Redirecting you shortly.")
     } catch (error) {
       const authError = error as AuthServiceError
-      if (authError.status === 401) {
+      const isBannedError =
+        authError.code === "USER_BANNED" ||
+        Boolean(authError.details?.["isBanned"])
+
+      if (isBannedError) {
+        const banReason =
+          typeof authError.details?.["banReason"] === "string"
+            ? (authError.details?.["banReason"] as string)
+            : undefined
+        loginForm.setStatus(
+          "error",
+          banReason
+            ? `Access denied: ${banReason}`
+            : authError.message ||
+                "Your account has been suspended. Please contact support."
+        )
+      } else if (authError.status === 401) {
         loginForm.setStatus(
           "error",
           "We couldn't verify those credentials. Please try again."
@@ -205,7 +221,8 @@ const Auth = () => {
       } else {
         loginForm.setStatus(
           "error",
-          "Something went wrong while signing you in. Please try again later."
+          authError.message ||
+            "Something went wrong while signing you in. Please try again later."
         )
       }
     }
@@ -301,6 +318,25 @@ const Auth = () => {
           API integration when you are.
         </p>
       </header>
+
+      {banNotice ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+          <p className="font-semibold">Account access restricted</p>
+          <p className="mt-1">
+            {banNotice.reason
+              ? `We can't sign you in because your account is suspended: ${banNotice.reason}`
+              : "We can't sign you in because your account is currently suspended."}
+          </p>
+          {banNotice.appealUrl ? (
+            <a
+              href={banNotice.appealUrl}
+              className="mt-2 inline-flex text-xs font-semibold text-amber-700 underline-offset-2 hover:underline"
+            >
+              Contact support to appeal
+            </a>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="mx-auto flex w-full max-w-xl flex-col gap-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <div className="flex items-center justify-center gap-2 rounded-full bg-slate-100 p-1 text-sm font-medium">

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -21,7 +21,7 @@ const PROFILE_TABS: ProfileTabConfig[] = [
 ]
 
 const Profile = () => {
-  const { user, isHydrated } = useAuth()
+  const { user, isHydrated, banNotice, isModerator, isAdmin } = useAuth()
   const {
     account: profileAccount,
     metrics,
@@ -48,9 +48,20 @@ const Profile = () => {
       return profileAccount ?? undefined
     }
 
+    const moderationDetails =
+      user?.banReason || user?.moderation
+        ? {
+            flagCount: user.moderation?.flagCount,
+            reviewedAt: user.moderation?.reviewedAt ?? null,
+            notes: user.moderation?.notes ?? user.banReason ?? null,
+          }
+        : undefined
+
     const baseAccount: ProfileAccountInfo = {
       name: user.name,
       email: user.email,
+      role: user.role,
+      moderation: moderationDetails,
     }
 
     if (!profileAccount) {
@@ -62,6 +73,8 @@ const Profile = () => {
       ...profileAccount,
       name: profileAccount.name ?? baseAccount.name,
       email: profileAccount.email ?? baseAccount.email,
+      role: profileAccount.role ?? baseAccount.role,
+      moderation: profileAccount.moderation ?? baseAccount.moderation,
     }
   }, [profileAccount, user])
 
@@ -150,6 +163,33 @@ const Profile = () => {
           </a>
         }
       />
+      {banNotice ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+          <p className="font-semibold">Account suspended</p>
+          <p className="mt-1">
+            {banNotice.reason
+              ? `Your account access is limited: ${banNotice.reason}`
+              : 'Our moderators have temporarily suspended your marketplace access.'}
+          </p>
+        </div>
+      ) : null}
+      {accountDetails?.moderation?.flagCount ? (
+        <div className="rounded-xl border border-amber-100 bg-amber-50/60 p-4 text-sm text-amber-800">
+          <p className="font-semibold">Community alerts</p>
+          <p className="mt-1">
+            You have {accountDetails.moderation.flagCount}{' '}
+            {accountDetails.moderation.flagCount === 1 ? 'active report' : 'active reports'} under review.
+            {isModerator || isAdmin
+              ? ' Review the flagged content to keep your listings compliant.'
+              : ' Our team will review these soon. Keep an eye on your inbox for updates.'}
+          </p>
+          {accountDetails.moderation.reviewedAt ? (
+            <p className="mt-1 text-xs text-amber-700">
+              Last reviewed on {accountDetails.moderation.reviewedAt}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
       {isError ? (
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           <p>We couldn&apos;t load your profile details right now.</p>

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -10,25 +10,89 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:4000
 
 export class AuthServiceError extends Error {
   status?: number
+  code?: string
+  details?: Record<string, unknown>
 
-  constructor(message: string, status?: number) {
+  constructor(
+    message: string,
+    status?: number,
+    code?: string,
+    details?: Record<string, unknown>
+  ) {
     super(message)
     this.name = "AuthServiceError"
     this.status = status
+    this.code = code
+    this.details = details
   }
 }
 
-const handleResponse = async (response: Response): Promise<AuthResponse> => {
-  const data = (await response.json().catch(() => ({}))) as Partial<AuthResponse> & {
+type AuthErrorResponse = Partial<AuthResponse> & {
     message?: string
+    code?: string
+    reason?: string
+    banReason?: string
+    bannedAt?: string | null
+    banExpiresAt?: string | null
+    appealUrl?: string | null
+    isBanned?: boolean
+    details?: Record<string, unknown>
+  } & {
+    moderation?: {
+      notes?: string | null
+      bannedAt?: string | null
+      banExpiresAt?: string | null
+      appealUrl?: string | null
+    }
   }
 
+const handleResponse = async (response: Response): Promise<AuthResponse> => {
+  const data = (await response.json().catch(() => ({}))) as AuthErrorResponse
+
   if (!response.ok) {
-    const message = data?.message ?? "Authentication request failed"
-    throw new AuthServiceError(message, response.status)
+    const banReason =
+      data?.banReason ??
+      data?.reason ??
+      (typeof data?.details?.banReason === "string"
+        ? (data.details.banReason as string)
+        : undefined) ??
+      data?.moderation?.notes ??
+      undefined
+
+    const isBannedResponse = Boolean(
+      data?.isBanned ||
+        data?.moderation ||
+        data?.code === "USER_BANNED" ||
+        response.status === 403
+    )
+
+    const details: Record<string, unknown> = {
+      ...((data?.details && typeof data.details === "object"
+        ? data.details
+        : {}) as Record<string, unknown>),
+      banReason,
+      bannedAt: data?.moderation?.bannedAt ?? data?.bannedAt ?? null,
+      banExpiresAt: data?.moderation?.banExpiresAt ?? data?.banExpiresAt ?? null,
+      appealUrl: data?.moderation?.appealUrl ?? data?.appealUrl ?? null,
+      isBanned: isBannedResponse,
+    }
+
+    const code = data?.code ?? (isBannedResponse ? "USER_BANNED" : undefined)
+    const message =
+      isBannedResponse
+        ? banReason
+          ? `Your account has been suspended: ${banReason}`
+          : "Your account has been suspended. Please contact support."
+        : data?.message ?? "Authentication request failed"
+
+    throw new AuthServiceError(message, response.status, code, details)
   }
 
   if (!data?.user || !data?.token) {
+    throw new AuthServiceError("Malformed authentication response")
+  }
+
+  if (typeof data.user.role !== "string" || typeof data.user.isBanned !== "boolean") {
     throw new AuthServiceError("Malformed authentication response")
   }
 

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,7 +1,23 @@
+export type UserRole = "user" | "moderator" | "admin"
+
+export type ModerationMetadata = {
+  bannedAt?: string | null
+  banExpiresAt?: string | null
+  reviewedAt?: string | null
+  reviewedBy?: string | null
+  flagCount?: number
+  appealUrl?: string | null
+  notes?: string | null
+}
+
 export type AuthUser = {
   id: number
   email: string
   name: string
+  role: UserRole
+  isBanned: boolean
+  banReason?: string | null
+  moderation?: ModerationMetadata
 }
 
 export type AuthResponse = {

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -4,6 +4,12 @@ export interface ProfileAccountInfo {
   location?: string
   memberSince?: string
   bio?: string
+  role?: string
+  moderation?: {
+    flagCount?: number
+    reviewedAt?: string | null
+    notes?: string | null
+  }
 }
 
 export interface ProfileAccountUpdateInput {


### PR DESCRIPTION
## Summary
- extend auth types to include roles, ban flags, and moderation metadata while validating stored sessions
- update the auth context, storage, and services to surface banned accounts, helper flags, and friendly ban errors
- refresh navigation, auth, and profile UIs to display role badges and moderation notices consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903e9ac27d0832b8f9d104fd58c4479